### PR TITLE
Update embed-resources example for v2

### DIFF
--- a/recipe/embed-resources/main.go
+++ b/recipe/embed-resources/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/GeertJohan/go.rice"
 	"github.com/labstack/echo"
+	"github.com/labstack/echo/engine/standard"
 )
 
 func main() {
@@ -12,15 +13,9 @@ func main() {
 	// the file server for rice. "app" is the folder where the files come from.
 	assetHandler := http.FileServer(rice.MustFindBox("app").HTTPBox())
 	// serves the index.html from rice
-	e.Get("/", func(c *echo.Context) error {
-		assetHandler.ServeHTTP(c.Response().Writer(), c.Request())
-		return nil
-	})
+	e.Get("/", standard.WrapHandler(assetHandler))
+
 	// servers other static files
-	e.Get("/static/*", func(c *echo.Context) error {
-		http.StripPrefix("/static/", assetHandler).
-			ServeHTTP(c.Response().Writer(), c.Request())
-		return nil
-	})
-	e.Run(":3000")
+	e.Get("/static/*", standard.WrapHandler(http.StripPrefix("/static/", assetHandler)))
+	e.Run(standard.New(":3000"))
 }

--- a/website/content/recipes/embed-resources.md
+++ b/website/content/recipes/embed-resources.md
@@ -16,5 +16,6 @@ menu:
 ### Maintainers
 
 - [caarlos0](https://github.com/caarlos0)
+- [maddie](https://github.com/maddie)
 
 ### [Source Code]({{< source "embed-resources" >}})


### PR DESCRIPTION
The example of using go.rice to embed resources within the application was outdated as of v2, this commit updates the example to make it work.

This is the first time I send a pull request to Echo project, please let me know if there's any problem with this commit/request.

Thanks!