### PR TITLE
Added updated JWT lib v3 compatibility fix

### DIFF
--- a/recipe/jwt/server.go
+++ b/recipe/jwt/server.go
@@ -19,9 +19,10 @@ func login(c echo.Context) error {
 		token := jwt.New(jwt.SigningMethodHS256)
 
 		// Set claims
-		token.Claims["name"] = "Jon Snow"
-		token.Claims["admin"] = true
-		token.Claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
+		claims := token.Claims.(jwt.MapClaims)
+		claims["name"] = "Jon Snow"
+		claims["admin"] = true
+		claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
 
 		// Generate encoded token and send it as response.
 		t, err := token.SignedString([]byte("secret"))
@@ -42,7 +43,8 @@ func accessible(c echo.Context) error {
 
 func restricted(c echo.Context) error {
 	user := c.Get("user").(*jwt.Token)
-	name := user.Claims["name"].(string)
+	claims := user.Claims.(jwt.MapClaims)
+	name := claims["name"].(string)
 	return c.String(http.StatusOK, "Welcome "+name+"!")
 }
 

--- a/vendor/github.com/dgrijalva/jwt-go/MIGRATION_GUIDE.md
+++ b/vendor/github.com/dgrijalva/jwt-go/MIGRATION_GUIDE.md
@@ -1,0 +1,96 @@
+## Migration Guide from v2 -> v3
+
+Version 3 adds several new, frequently requested features.  To do so, it introduces a few breaking changes.  We've worked to keep these as minimal as possible.  This guide explains the breaking changes and how you can quickly update your code.
+
+### `Token.Claims` is now an interface type
+
+The most requested feature from the 2.0 verison of this library was the ability to provide a custom type to the JSON parser for claims. This was implemented by introducing a new interface, `Claims`, to replace `map[string]interface{}`.  We also included two concrete implementations of `Claims`: `MapClaims` and `StandardClaims`.
+
+`MapClaims` is an alias for `map[string]interface{}` with built in validation behavior.  It is the default claims type when using `Parse`.  The usage is unchanged except you must type cast the claims property.
+
+The old example for parsing a token looked like this..
+
+```go
+	if token, err := jwt.Parse(tokenString, keyLookupFunc); err == nil {
+		fmt.Printf("Token for user %v expires %v", token.Claims["user"], token.Claims["exp"])
+	}
+```
+
+is now directly mapped to...
+
+```go
+	if token, err := jwt.Parse(tokenString, keyLookupFunc); err == nil {
+		claims := token.Claims.(jwt.MapClaims)
+		fmt.Printf("Token for user %v expires %v", claims["user"], claims["exp"])
+	}
+```
+
+`StandardClaims` is designed to be embedded in your custom type.  You can supply a custom claims type with the new `ParseWithClaims` function.  Here's an example of using a custom claims type.
+
+```go
+	type MyCustomClaims struct {
+		User string
+		*StandardClaims
+	}
+	
+	if token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, keyLookupFunc); err == nil {
+		claims := token.Claims.(*MyCustomClaims)
+		fmt.Printf("Token for user %v expires %v", claims.User, claims.StandardClaims.ExpiresAt)
+	}
+```
+
+### `ParseFromRequest` has been moved
+
+To keep this library focused on the tokens without becoming overburdened with complex request processing logic, `ParseFromRequest` and its new companion `ParseFromRequestWithClaims` have been moved to a subpackage, `request`.  The method signatues have also been augmented to receive a new argument: `Extractor`.
+
+`Extractors` do the work of picking the token string out of a request.  The interface is simple and composable.
+
+This simple parsing example:
+
+```go
+	if token, err := jwt.ParseFromRequest(tokenString, req, keyLookupFunc); err == nil {
+		fmt.Printf("Token for user %v expires %v", token.Claims["user"], token.Claims["exp"])
+	}
+```
+
+is directly mapped to:
+
+```go
+	if token, err := request.ParseFromRequest(tokenString, request.OAuth2Extractor, req, keyLookupFunc); err == nil {
+		fmt.Printf("Token for user %v expires %v", token.Claims["user"], token.Claims["exp"])
+	}
+```
+
+There are several concrete `Extractor` types provided for your convenience:
+
+* `HeaderExtractor` will search a list of headers until one contains content.
+* `ArgumentExtractor` will search a list of keys in request query and form arguments until one contains content.
+* `MultiExtractor` will try a list of `Extractors` in order until one returns content.
+* `AuthorizationHeaderExtractor` will look in the `Authorization` header for a `Bearer` token.
+* `OAuth2Extractor` searches the places an OAuth2 token would be specified (per the spec): `Authorization` header and `access_token` argument
+* `PostExtractionFilter` wraps an `Extractor`, allowing you to process the content before it's parsed.  A simple example is stripping the `Bearer ` text from a header
+
+
+### RSA signing methods no longer accept `[]byte` keys
+
+Due to a [critical vulnerability](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/), we've decided the convenience of accepting `[]byte` instead of `rsa.PublicKey` or `rsa.PrivateKey` isn't worth the risk of misuse.
+
+To replace this behavior, we've added two helper methods: `ParseRSAPrivateKeyFromPEM(key []byte) (*rsa.PrivateKey, error)` and `ParseRSAPublicKeyFromPEM(key []byte) (*rsa.PublicKey, error)`.  These are just simple helpers for unpacking PEM encoded PKCS1 and PKCS8 keys. If your keys are encoded any other way, all you need to do is convert them to the `crypto/rsa` package's types.
+
+```go 
+	func keyLookupFunc(*Token) (interface{}, error) {
+		// Don't forget to validate the alg is what you expect:
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		}
+		
+		// Look up key 
+		key, err := lookupPublicKey(token.Header["kid"])
+		if err != nil {
+			return nil, err
+		}
+		
+		// Unpack key from PEM encoded PKCS8
+		return jwt.ParseRSAPublicKeyFromPEM(key)
+	}
+```

--- a/vendor/github.com/dgrijalva/jwt-go/README.md
+++ b/vendor/github.com/dgrijalva/jwt-go/README.md
@@ -1,12 +1,15 @@
-A [go](http://www.golang.org) (or 'golang' for search engine friendliness) implementation of [JSON Web Tokens](http://self-issued.info/docs/draft-jones-json-web-token.html)
+A [go](http://www.golang.org) (or 'golang' for search engine friendliness) implementation of [JSON Web Tokens](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html)
 
 [![Build Status](https://travis-ci.org/dgrijalva/jwt-go.svg?branch=master)](https://travis-ci.org/dgrijalva/jwt-go)
 
-**BREAKING CHANGES COMING:*** Version 3.0.0 is almost complete. It will include _a lot_ of changes including a few that break the API.  We've tried to break as few things as possible, so there should just be a few type signature changes.  A full list of breaking changes will be available before 3.0.0 lands.  If you would like to have any input befor 3.0.0 is locked, now's the time to review and provide feedback.
+**BREAKING CHANGES:*** Version 3.0.0 is here. It includes _a lot_ of changes including a few that break the API.  We've tried to break as few things as possible, so there should just be a few type signature changes.  A full list of breaking changes is available in `VERSION_HISTORY.md`.  See `MIGRATION_GUIDE.md` for more information on updating your code.
 
 **NOTICE:** A vulnerability in JWT was [recently published](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/).  As this library doesn't force users to validate the `alg` is what they expected, it's possible your usage is effected.  There will be an update soon to remedy this, and it will likey require backwards-incompatible changes to the API.  In the short term, please make sure your implementation verifies the `alg` is what you expect.
 
+
 ## What the heck is a JWT?
+
+JWT.io has [a great introduction](https://jwt.io/introduction) to JSON Web Tokens.
 
 In short, it's a signed JSON object that does something useful (for example, authentication).  It's commonly used for `Bearer` tokens in Oauth 2.  A token is made of three parts, separated by `.`'s.  The first two parts are JSON objects, that have been [base64url](http://tools.ietf.org/html/rfc4648) encoded.  The last part is the signature, encoded the same way.
 
@@ -18,43 +21,25 @@ The part in the middle is the interesting bit.  It's called the Claims and conta
 
 This library supports the parsing and verification as well as the generation and signing of JWTs.  Current supported signing algorithms are HMAC SHA, RSA, RSA-PSS, and ECDSA, though hooks are present for adding your own.
 
-## Parse and Verify
+## Examples
 
-Parsing and verifying tokens is pretty straight forward.  You pass in the token and a function for looking up the key.  This is done as a callback since you may need to parse the token to find out what signing method and key was used.
+See [the project documentation](https://godoc.org/github.com/dgrijalva/jwt-go) for examples of usage:
 
-```go
-	token, err := jwt.Parse(myToken, func(token *jwt.Token) (interface{}, error) {
-		// Don't forget to validate the alg is what you expect:
-		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
-		}
-		return myLookupKey(token.Header["kid"]), nil
-	})
-
-	if err == nil && token.Valid {
-		deliverGoodness("!")
-	} else {
-		deliverUtterRejection(":(")
-	}
-```
-	
-## Create a token
-
-```go
-	// Create the token
-	token := jwt.New(jwt.SigningMethodHS256)
-	// Set some claims
-	token.Claims["foo"] = "bar"
-	token.Claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
-	// Sign and get the complete encoded token as a string
-	tokenString, err := token.SignedString(mySigningKey)
-```	
+* [Simple example of parsing and validating a token](https://godoc.org/github.com/dgrijalva/jwt-go#example-Parse--Hmac)
+* [Simple example of building and signing a token](https://godoc.org/github.com/dgrijalva/jwt-go#example-New--Hmac)
+* [Directory of Examples](https://godoc.org/github.com/dgrijalva/jwt-go#pkg-examples)
 
 ## Extensions
 
 This library publishes all the necessary components for adding your own signing methods.  Simply implement the `SigningMethod` interface and register a factory method using `RegisterSigningMethod`.  
 
 Here's an example of an extension that integrates with the Google App Engine signing tools: https://github.com/someone1/gcp-jwt-go
+
+## Compliance
+
+This library was last reviewed to comply with [RTF 7519](http://www.rfc-editor.org/info/rfc7519) dated May 2015 with a few notable differences: 
+
+* In order to protect against accidental use of [Unsecured JWTs](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#UnsecuredJWT), tokens using `alg=none` will only be accepted if the constant `jwt.UnsafeAllowNoneSignatureType` is provided as the key.
 
 ## Project Status & Versioning
 
@@ -97,4 +82,4 @@ Without going too far down the rabbit hole, here's a description of the interact
 
 Documentation can be found [on godoc.org](http://godoc.org/github.com/dgrijalva/jwt-go).
 
-The command line utility included in this project (cmd/jwt) provides a straightforward example of token creation and parsing as well as a useful tool for debugging your own integration.  For a more http centric example, see [this gist](https://gist.github.com/cryptix/45c33ecf0ae54828e63b).
+The command line utility included in this project (cmd/jwt) provides a straightforward example of token creation and parsing as well as a useful tool for debugging your own integration.  You'll also find several implementation examples in to documentation.

--- a/vendor/github.com/dgrijalva/jwt-go/VERSION_HISTORY.md
+++ b/vendor/github.com/dgrijalva/jwt-go/VERSION_HISTORY.md
@@ -1,8 +1,32 @@
 ## `jwt-go` Version History
 
-#### 2.6.0
+#### 3.0.0
 
-This will likely be the last backwards compatible release before 3.0.0.
+* **Compatibility Breaking Changes**: See MIGRATION_GUIDE.md for tips on updating your code
+	* Dropped support for `[]byte` keys when using RSA signing methods.  This convenience feature could contribute to security vulnerabilities involving mismatched key types with signing methods.
+	* `ParseFromRequest` has been moved to `request` subpackage and usage has changed
+	* The `Claims` property on `Token` is now type `Claims` instead of `map[string]interface{}`.  The default value is type `MapClaims`, which is an alias to `map[string]interface{}`.  This makes it possible to use a custom type when decoding claims.
+* Other Additions and Changes
+	* Added `Claims` interface type to allow users to decode the claims into a custom type
+	* Added `ParseWithClaims`, which takes a third argument of type `Claims`.  Use this function instead of `Parse` if you have a custom type you'd like to decode into.
+	* Dramatically improved the functionality and flexibility of `ParseFromRequest`, which is now in the `request` subpackage
+	* Added `ParseFromRequestWithClaims` which is the `FromRequest` equivalent of `ParseWithClaims`
+	* Added new interface type `Extractor`, which is used for extracting JWT strings from http requests.  Used with `ParseFromRequest` and `ParseFromRequestWithClaims`.
+	* Added several new, more specific, validation errors to error type bitmask
+	* Moved examples from README to executable example files
+	* Signing method registry is now thread safe
+	* Added new property to `ValidationError`, which contains the raw error returned by calls made by parse/verify (such as those returned by keyfunc or json parser)
+
+#### 2.7.0
+
+This will likely be the last backwards compatible release before 3.0.0, excluding essential bug fixes.
+
+* Added new option `-show` to the `jwt` command that will just output the decoded token without verifying
+* Error text for expired tokens includes how long it's been expired
+* Fixed incorrect error returned from `ParseRSAPublicKeyFromPEM`
+* Documentation updates
+
+#### 2.6.0
 
 * Exposed inner error within ValidationError
 * Fixed validation errors when using UseJSONNumber flag

--- a/vendor/github.com/dgrijalva/jwt-go/claims.go
+++ b/vendor/github.com/dgrijalva/jwt-go/claims.go
@@ -1,0 +1,134 @@
+package jwt
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"time"
+)
+
+// For a type to be a Claims object, it must just have a Valid method that determines
+// if the token is invalid for any supported reason
+type Claims interface {
+	Valid() error
+}
+
+// Structured version of Claims Section, as referenced at
+// https://tools.ietf.org/html/rfc7519#section-4.1
+// See examples for how to use this with your own claim types
+type StandardClaims struct {
+	Audience  string `json:"aud,omitempty"`
+	ExpiresAt int64  `json:"exp,omitempty"`
+	Id        string `json:"jti,omitempty"`
+	IssuedAt  int64  `json:"iat,omitempty"`
+	Issuer    string `json:"iss,omitempty"`
+	NotBefore int64  `json:"nbf,omitempty"`
+	Subject   string `json:"sub,omitempty"`
+}
+
+// Validates time based claims "exp, iat, nbf".
+// There is no accounting for clock skew.
+// As well, if any of the above claims are not in the token, it will still
+// be considered a valid claim.
+func (c StandardClaims) Valid() error {
+	vErr := new(ValidationError)
+	now := TimeFunc().Unix()
+
+	// The claims below are optional, by default, so if they are set to the
+	// default value in Go, let's not fail the verification for them.
+	if c.VerifyExpiresAt(now, false) == false {
+		delta := time.Unix(now, 0).Sub(time.Unix(c.ExpiresAt, 0))
+		vErr.Inner = fmt.Errorf("token is expired by %v", delta)
+		vErr.Errors |= ValidationErrorExpired
+	}
+
+	if c.VerifyIssuedAt(now, false) == false {
+		vErr.Inner = fmt.Errorf("Token used before issued")
+		vErr.Errors |= ValidationErrorIssuedAt
+	}
+
+	if c.VerifyNotBefore(now, false) == false {
+		vErr.Inner = fmt.Errorf("token is not valid yet")
+		vErr.Errors |= ValidationErrorNotValidYet
+	}
+
+	if vErr.valid() {
+		return nil
+	}
+
+	return vErr
+}
+
+// Compares the aud claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyAudience(cmp string, req bool) bool {
+	return verifyAud(c.Audience, cmp, req)
+}
+
+// Compares the exp claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyExpiresAt(cmp int64, req bool) bool {
+	return verifyExp(c.ExpiresAt, cmp, req)
+}
+
+// Compares the iat claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyIssuedAt(cmp int64, req bool) bool {
+	return verifyIat(c.IssuedAt, cmp, req)
+}
+
+// Compares the iss claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyIssuer(cmp string, req bool) bool {
+	return verifyIss(c.Issuer, cmp, req)
+}
+
+// Compares the nbf claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyNotBefore(cmp int64, req bool) bool {
+	return verifyNbf(c.NotBefore, cmp, req)
+}
+
+// ----- helpers
+
+func verifyAud(aud string, cmp string, required bool) bool {
+	if aud == "" {
+		return !required
+	}
+	if subtle.ConstantTimeCompare([]byte(aud), []byte(cmp)) != 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
+func verifyExp(exp int64, now int64, required bool) bool {
+	if exp == 0 {
+		return !required
+	}
+	return now <= exp
+}
+
+func verifyIat(iat int64, now int64, required bool) bool {
+	if iat == 0 {
+		return !required
+	}
+	return now >= iat
+}
+
+func verifyIss(iss string, cmp string, required bool) bool {
+	if iss == "" {
+		return !required
+	}
+	if subtle.ConstantTimeCompare([]byte(iss), []byte(cmp)) != 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
+func verifyNbf(nbf int64, now int64, required bool) bool {
+	if nbf == 0 {
+		return !required
+	}
+	return now >= nbf
+}

--- a/vendor/github.com/dgrijalva/jwt-go/cmd/jwt/app.go
+++ b/vendor/github.com/dgrijalva/jwt-go/cmd/jwt/app.go
@@ -166,7 +166,7 @@ func signToken() error {
 	}
 
 	// parse the JSON of the claims
-	var claims map[string]interface{}
+	var claims jwt.MapClaims
 	if err := json.Unmarshal(tokData, &claims); err != nil {
 		return fmt.Errorf("Couldn't parse claims JSON: %v", err)
 	}
@@ -185,8 +185,7 @@ func signToken() error {
 	}
 
 	// create a new token
-	token := jwt.New(alg)
-	token.Claims = claims
+	token := jwt.NewWithClaims(alg, claims)
 
 	if isEs() {
 		if k, ok := key.([]byte); !ok {

--- a/vendor/github.com/dgrijalva/jwt-go/ecdsa.go
+++ b/vendor/github.com/dgrijalva/jwt-go/ecdsa.go
@@ -69,7 +69,7 @@ func (m *SigningMethodECDSA) Verify(signingString, signature string, key interfa
 	case *ecdsa.PublicKey:
 		ecdsaKey = k
 	default:
-		return ErrInvalidKey
+		return ErrInvalidKeyType
 	}
 
 	if len(sig) != 2*m.KeySize {
@@ -103,7 +103,7 @@ func (m *SigningMethodECDSA) Sign(signingString string, key interface{}) (string
 	case *ecdsa.PrivateKey:
 		ecdsaKey = k
 	default:
-		return "", ErrInvalidKey
+		return "", ErrInvalidKeyType
 	}
 
 	// Create the hasher

--- a/vendor/github.com/dgrijalva/jwt-go/errors.go
+++ b/vendor/github.com/dgrijalva/jwt-go/errors.go
@@ -6,9 +6,9 @@ import (
 
 // Error constants
 var (
-	ErrInvalidKey       = errors.New("key is invalid or of invalid type")
-	ErrHashUnavailable  = errors.New("the requested hash function is unavailable")
-	ErrNoTokenInRequest = errors.New("no token present in request")
+	ErrInvalidKey      = errors.New("key is invalid")
+	ErrInvalidKeyType  = errors.New("key is of invalid type")
+	ErrHashUnavailable = errors.New("the requested hash function is unavailable")
 )
 
 // The errors that might occur when parsing and validating a token
@@ -16,14 +16,21 @@ const (
 	ValidationErrorMalformed        uint32 = 1 << iota // Token is malformed
 	ValidationErrorUnverifiable                        // Token could not be verified because of signing problems
 	ValidationErrorSignatureInvalid                    // Signature validation failed
-	ValidationErrorExpired                             // Exp validation failed
-	ValidationErrorNotValidYet                         // NBF validation failed
+
+	// Standard Claim validation errors
+	ValidationErrorAudience      // AUD validation failed
+	ValidationErrorExpired       // EXP validation failed
+	ValidationErrorIssuedAt      // IAT validation failed
+	ValidationErrorIssuer        // ISS validation failed
+	ValidationErrorNotValidYet   // NBF validation failed
+	ValidationErrorId            // JTI validation failed
+	ValidationErrorClaimsInvalid // Generic claims validation error
 )
 
 // Helper for constructing a ValidationError with a string error message
 func NewValidationError(errorText string, errorFlags uint32) *ValidationError {
 	return &ValidationError{
-		Inner:  errors.New(errorText),
+		text:   errorText,
 		Errors: errorFlags,
 	}
 }
@@ -32,11 +39,16 @@ func NewValidationError(errorText string, errorFlags uint32) *ValidationError {
 type ValidationError struct {
 	Inner  error  // stores the error returned by external dependencies, i.e.: KeyFunc
 	Errors uint32 // bitfield.  see ValidationError... constants
+	text   string // errors that do not have a valid error just have text
 }
 
 // Validation error is an error type
 func (e ValidationError) Error() string {
-	if e.Inner == nil {
+	if e.Inner != nil {
+		return e.Inner.Error()
+	} else if e.text != "" {
+		return e.text
+	} else {
 		return "token is invalid"
 	}
 	return e.Inner.Error()

--- a/vendor/github.com/dgrijalva/jwt-go/example_test.go
+++ b/vendor/github.com/dgrijalva/jwt-go/example_test.go
@@ -6,32 +6,93 @@ import (
 	"time"
 )
 
-func ExampleParse(myToken string, myLookupKey func(interface{}) (interface{}, error)) {
-	token, err := jwt.Parse(myToken, func(token *jwt.Token) (interface{}, error) {
-		return myLookupKey(token.Header["kid"])
+// Example (atypical) using the StandardClaims type by itself to parse a token.
+// The StandardClaims type is designed to be embedded into your custom types
+// to provide standard validation features.  You can use it alone, but there's
+// no way to retrieve other fields after parsing.
+// See the CustomClaimsType example for intended usage.
+func ExampleNewWithClaims_standardClaims() {
+	mySigningKey := []byte("AllYourBase")
+
+	// Create the Claims
+	claims := &jwt.StandardClaims{
+		ExpiresAt: 15000,
+		Issuer:    "test",
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	ss, err := token.SignedString(mySigningKey)
+	fmt.Printf("%v %v", ss, err)
+	//Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.QsODzZu3lUZMVdhbO76u3Jv02iYCvEHcYVUI1kOWEU0 <nil>
+}
+
+// Example creating a token using a custom claims type.  The StandardClaim is embedded
+// in the custom type to allow for easy encoding, parsing and validation of standard claims.
+func ExampleNewWithClaims_customClaimsType() {
+	mySigningKey := []byte("AllYourBase")
+
+	type MyCustomClaims struct {
+		Foo string `json:"foo"`
+		jwt.StandardClaims
+	}
+
+	// Create the Claims
+	claims := MyCustomClaims{
+		"bar",
+		jwt.StandardClaims{
+			ExpiresAt: 15000,
+			Issuer:    "test",
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	ss, err := token.SignedString(mySigningKey)
+	fmt.Printf("%v %v", ss, err)
+	//Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c <nil>
+}
+
+// Example creating a token using a custom claims type.  The StandardClaim is embedded
+// in the custom type to allow for easy encoding, parsing and validation of standard claims.
+func ExampleParseWithClaims_customClaimsType() {
+	tokenString := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c"
+
+	type MyCustomClaims struct {
+		Foo string `json:"foo"`
+		jwt.StandardClaims
+	}
+
+	// sample token is expired.  override time so it parses as valid
+	at(time.Unix(0, 0), func() {
+		token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
+			return []byte("AllYourBase"), nil
+		})
+
+		if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
+			fmt.Printf("%v %v", claims.Foo, claims.StandardClaims.ExpiresAt)
+		} else {
+			fmt.Println(err)
+		}
 	})
 
-	if err == nil && token.Valid {
-		fmt.Println("Your token is valid.  I like your style.")
-	} else {
-		fmt.Println("This token is terrible!  I cannot accept this.")
+	// Output: bar 15000
+}
+
+// Override time value for tests.  Restore default value after.
+func at(t time.Time, f func()) {
+	jwt.TimeFunc = func() time.Time {
+		return t
 	}
+	f()
+	jwt.TimeFunc = time.Now
 }
 
-func ExampleNew(mySigningKey []byte) (string, error) {
-	// Create the token
-	token := jwt.New(jwt.SigningMethodHS256)
-	// Set some claims
-	token.Claims["foo"] = "bar"
-	token.Claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
-	// Sign and get the complete encoded token as a string
-	tokenString, err := token.SignedString(mySigningKey)
-	return tokenString, err
-}
+// An example of parsing the error types using bitfield checks
+func ExampleParse_errorChecking() {
+	// Token from another example.  This token is expired
+	var tokenString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c"
 
-func ExampleParse_errorChecking(myToken string, myLookupKey func(interface{}) (interface{}, error)) {
-	token, err := jwt.Parse(myToken, func(token *jwt.Token) (interface{}, error) {
-		return myLookupKey(token.Header["kid"])
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		return []byte("AllYourBase"), nil
 	})
 
 	if token.Valid {
@@ -49,4 +110,5 @@ func ExampleParse_errorChecking(myToken string, myLookupKey func(interface{}) (i
 		fmt.Println("Couldn't handle this token:", err)
 	}
 
+	// Output: Timing is everything
 }

--- a/vendor/github.com/dgrijalva/jwt-go/hmac.go
+++ b/vendor/github.com/dgrijalva/jwt-go/hmac.go
@@ -49,7 +49,7 @@ func (m *SigningMethodHMAC) Verify(signingString, signature string, key interfac
 	// Verify the key is the right type
 	keyBytes, ok := key.([]byte)
 	if !ok {
-		return ErrInvalidKey
+		return ErrInvalidKeyType
 	}
 
 	// Decode signature, for comparison

--- a/vendor/github.com/dgrijalva/jwt-go/hmac_example_test.go
+++ b/vendor/github.com/dgrijalva/jwt-go/hmac_example_test.go
@@ -1,0 +1,64 @@
+package jwt_test
+
+import (
+	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"io/ioutil"
+	"time"
+)
+
+// For HMAC signing method, the key can be any []byte. It is recommended to generate
+// a key using crypto/rand or something equivalent. You need the same key for signing
+// and validating.
+var hmacSampleSecret []byte
+
+func init() {
+	// Load sample key data
+	if keyData, e := ioutil.ReadFile("test/hmacTestKey"); e == nil {
+		hmacSampleSecret = keyData
+	} else {
+		panic(e)
+	}
+}
+
+// Example creating, signing, and encoding a JWT token using the HMAC signing method
+func ExampleNew_hmac() {
+	// Create a new token object, specifying signing method and the claims
+	// you would like it to contain.
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"foo": "bar",
+		"nbf": time.Date(2015, 10, 10, 12, 0, 0, 0, time.UTC).Unix(),
+	})
+
+	// Sign and get the complete encoded token as a string using the secret
+	tokenString, err := token.SignedString(hmacSampleSecret)
+
+	fmt.Println(tokenString, err)
+	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJuYmYiOjE0NDQ0Nzg0MDB9.u1riaD1rW97opCoAuRCTy4w58Br-Zk-bh7vLiRIsrpU <nil>
+}
+
+// Example parsing and validating a token using the HMAC signing method
+func ExampleParse_hmac() {
+	// sample token string taken from the New example
+	tokenString := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJuYmYiOjE0NDQ0Nzg0MDB9.u1riaD1rW97opCoAuRCTy4w58Br-Zk-bh7vLiRIsrpU"
+
+	// Parse takes the token string and a function for looking up the key. The latter is especially
+	// useful if you use multiple keys for your application.  The standard is to use 'kid' in the
+	// head of the token to identify which key to use, but the parsed token (head and claims) is provided
+	// to the callback, providing flexibility.
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		// Don't forget to validate the alg is what you expect:
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		}
+		return hmacSampleSecret, nil
+	})
+
+	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+		fmt.Println(claims["foo"], claims["nbf"])
+	} else {
+		fmt.Println(err)
+	}
+
+	// Output: bar 1.4444784e+09
+}

--- a/vendor/github.com/dgrijalva/jwt-go/http_example_test.go
+++ b/vendor/github.com/dgrijalva/jwt-go/http_example_test.go
@@ -1,0 +1,216 @@
+package jwt_test
+
+// Example HTTP auth using asymmetric crypto/RSA keys
+// This is based on a (now outdated) example at https://gist.github.com/cryptix/45c33ecf0ae54828e63b
+
+import (
+	"bytes"
+	"crypto/rsa"
+	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go/request"
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// location of the files used for signing and verification
+const (
+	privKeyPath = "test/sample_key"     // openssl genrsa -out app.rsa keysize
+	pubKeyPath  = "test/sample_key.pub" // openssl rsa -in app.rsa -pubout > app.rsa.pub
+)
+
+var (
+	verifyKey  *rsa.PublicKey
+	signKey    *rsa.PrivateKey
+	serverPort int
+	// storing sample username/password pairs
+	// don't do this on a real server
+	users = map[string]string{
+		"test": "known",
+	}
+)
+
+// read the key files before starting http handlers
+func init() {
+	signBytes, err := ioutil.ReadFile(privKeyPath)
+	fatal(err)
+
+	signKey, err = jwt.ParseRSAPrivateKeyFromPEM(signBytes)
+	fatal(err)
+
+	verifyBytes, err := ioutil.ReadFile(pubKeyPath)
+	fatal(err)
+
+	verifyKey, err = jwt.ParseRSAPublicKeyFromPEM(verifyBytes)
+	fatal(err)
+
+	http.HandleFunc("/authenticate", authHandler)
+	http.HandleFunc("/restricted", restrictedHandler)
+
+	// Setup listener
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{})
+	serverPort = listener.Addr().(*net.TCPAddr).Port
+
+	log.Println("Listening...")
+	go func() {
+		fatal(http.Serve(listener, nil))
+	}()
+}
+
+var start func()
+
+func fatal(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Define some custom types were going to use within our tokens
+type CustomerInfo struct {
+	Name string
+	Kind string
+}
+
+type CustomClaimsExample struct {
+	*jwt.StandardClaims
+	TokenType string
+	CustomerInfo
+}
+
+func Example_getTokenViaHTTP() {
+	// See func authHandler for an example auth handler that produces a token
+	res, err := http.PostForm(fmt.Sprintf("http://localhost:%v/authenticate", serverPort), url.Values{
+		"user": {"test"},
+		"pass": {"known"},
+	})
+	if err != nil {
+		fatal(err)
+	}
+
+	if res.StatusCode != 200 {
+		fmt.Println("Unexpected status code", res.StatusCode)
+	}
+
+	// Read the token out of the response body
+	buf := new(bytes.Buffer)
+	io.Copy(buf, res.Body)
+	res.Body.Close()
+	tokenString := strings.TrimSpace(buf.String())
+
+	// Parse the token
+	token, err := jwt.ParseWithClaims(tokenString, &CustomClaimsExample{}, func(token *jwt.Token) (interface{}, error) {
+		// since we only use the one private key to sign the tokens,
+		// we also only use its public counter part to verify
+		return verifyKey, nil
+	})
+	fatal(err)
+
+	claims := token.Claims.(*CustomClaimsExample)
+	fmt.Println(claims.CustomerInfo.Name)
+
+	//Output: test
+}
+
+func Example_useTokenViaHTTP() {
+
+	// Make a sample token
+	// In a real world situation, this token will have been acquired from
+	// some other API call (see Example_getTokenViaHTTP)
+	token, err := createToken("foo")
+	fatal(err)
+
+	// Make request.  See func restrictedHandler for example request processor
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%v/restricted", serverPort), nil)
+	fatal(err)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", token))
+	res, err := http.DefaultClient.Do(req)
+	fatal(err)
+
+	// Read the response body
+	buf := new(bytes.Buffer)
+	io.Copy(buf, res.Body)
+	res.Body.Close()
+	fmt.Println(buf.String())
+
+	// Output: Welcome, foo
+}
+
+func createToken(user string) (string, error) {
+	// create a signer for rsa 256
+	t := jwt.New(jwt.GetSigningMethod("RS256"))
+
+	// set our claims
+	t.Claims = &CustomClaimsExample{
+		&jwt.StandardClaims{
+			// set the expire time
+			// see http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-20#section-4.1.4
+			ExpiresAt: time.Now().Add(time.Minute * 1).Unix(),
+		},
+		"level1",
+		CustomerInfo{user, "human"},
+	}
+
+	// Creat token string
+	return t.SignedString(signKey)
+}
+
+// reads the form values, checks them and creates the token
+func authHandler(w http.ResponseWriter, r *http.Request) {
+	// make sure its post
+	if r.Method != "POST" {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintln(w, "No POST", r.Method)
+		return
+	}
+
+	user := r.FormValue("user")
+	pass := r.FormValue("pass")
+
+	log.Printf("Authenticate: user[%s] pass[%s]\n", user, pass)
+
+	// check values
+	if user != "test" || pass != "known" {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprintln(w, "Wrong info")
+		return
+	}
+
+	tokenString, err := createToken(user)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, "Sorry, error while Signing Token!")
+		log.Printf("Token Signing error: %v\n", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/jwt")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, tokenString)
+}
+
+// only accessible with a valid token
+func restrictedHandler(w http.ResponseWriter, r *http.Request) {
+	// Get token from request
+	token, err := request.ParseFromRequestWithClaims(r, request.OAuth2Extractor, &CustomClaimsExample{}, func(token *jwt.Token) (interface{}, error) {
+		// since we only use the one private key to sign the tokens,
+		// we also only use its public counter part to verify
+		return verifyKey, nil
+	})
+
+	// If the token is missing or invalid, return error
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprintln(w, "Invalid token:", err)
+		return
+	}
+
+	// Token is valid
+	fmt.Fprintln(w, "Welcome,", token.Claims.(*CustomClaimsExample).Name)
+	return
+}

--- a/vendor/github.com/dgrijalva/jwt-go/map_claims.go
+++ b/vendor/github.com/dgrijalva/jwt-go/map_claims.go
@@ -1,0 +1,94 @@
+package jwt
+
+import (
+	"encoding/json"
+	"errors"
+	// "fmt"
+)
+
+// Claims type that uses the map[string]interface{} for JSON decoding
+// This is the default claims type if you don't supply one
+type MapClaims map[string]interface{}
+
+// Compares the aud claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
+	aud, _ := m["aud"].(string)
+	return verifyAud(aud, cmp, req)
+}
+
+// Compares the exp claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
+	switch exp := m["exp"].(type) {
+	case float64:
+		return verifyExp(int64(exp), cmp, req)
+	case json.Number:
+		v, _ := exp.Int64()
+		return verifyExp(v, cmp, req)
+	}
+	return req == false
+}
+
+// Compares the iat claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
+	switch iat := m["iat"].(type) {
+	case float64:
+		return verifyIat(int64(iat), cmp, req)
+	case json.Number:
+		v, _ := iat.Int64()
+		return verifyIat(v, cmp, req)
+	}
+	return req == false
+}
+
+// Compares the iss claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
+	iss, _ := m["iss"].(string)
+	return verifyIss(iss, cmp, req)
+}
+
+// Compares the nbf claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
+	switch nbf := m["nbf"].(type) {
+	case float64:
+		return verifyNbf(int64(nbf), cmp, req)
+	case json.Number:
+		v, _ := nbf.Int64()
+		return verifyNbf(v, cmp, req)
+	}
+	return req == false
+}
+
+// Validates time based claims "exp, iat, nbf".
+// There is no accounting for clock skew.
+// As well, if any of the above claims are not in the token, it will still
+// be considered a valid claim.
+func (m MapClaims) Valid() error {
+	vErr := new(ValidationError)
+	now := TimeFunc().Unix()
+
+	if m.VerifyExpiresAt(now, false) == false {
+		vErr.Inner = errors.New("Token is expired")
+		vErr.Errors |= ValidationErrorExpired
+	}
+
+	if m.VerifyIssuedAt(now, false) == false {
+		vErr.Inner = errors.New("Token used before issued")
+		vErr.Errors |= ValidationErrorIssuedAt
+	}
+
+	if m.VerifyNotBefore(now, false) == false {
+		vErr.Inner = errors.New("Token is not valid yet")
+		vErr.Errors |= ValidationErrorNotValidYet
+	}
+
+	if vErr.valid() {
+		return nil
+	}
+
+	return vErr
+}

--- a/vendor/github.com/dgrijalva/jwt-go/parser_test.go
+++ b/vendor/github.com/dgrijalva/jwt-go/parser_test.go
@@ -1,32 +1,36 @@
 package jwt_test
 
 import (
+	"crypto/rsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go/test"
 )
 
 var keyFuncError error = fmt.Errorf("error loading key")
 
 var (
-	jwtTestDefaultKey []byte
+	jwtTestDefaultKey *rsa.PublicKey
 	defaultKeyFunc    jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) { return jwtTestDefaultKey, nil }
 	emptyKeyFunc      jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) { return nil, nil }
 	errorKeyFunc      jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) { return nil, keyFuncError }
 	nilKeyFunc        jwt.Keyfunc = nil
 )
 
+func init() {
+	jwtTestDefaultKey = test.LoadRSAPublicKeyFromDisk("test/sample_key.pub")
+}
+
 var jwtTestData = []struct {
 	name        string
 	tokenString string
 	keyfunc     jwt.Keyfunc
-	claims      map[string]interface{}
+	claims      jwt.Claims
 	valid       bool
 	errors      uint32
 	parser      *jwt.Parser
@@ -35,7 +39,7 @@ var jwtTestData = []struct {
 		"basic",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar"},
+		jwt.MapClaims{"foo": "bar"},
 		true,
 		0,
 		nil,
@@ -44,7 +48,7 @@ var jwtTestData = []struct {
 		"basic expired",
 		"", // autogen
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar", "exp": float64(time.Now().Unix() - 100)},
+		jwt.MapClaims{"foo": "bar", "exp": float64(time.Now().Unix() - 100)},
 		false,
 		jwt.ValidationErrorExpired,
 		nil,
@@ -53,7 +57,7 @@ var jwtTestData = []struct {
 		"basic nbf",
 		"", // autogen
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar", "nbf": float64(time.Now().Unix() + 100)},
+		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100)},
 		false,
 		jwt.ValidationErrorNotValidYet,
 		nil,
@@ -62,7 +66,7 @@ var jwtTestData = []struct {
 		"expired and nbf",
 		"", // autogen
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar", "nbf": float64(time.Now().Unix() + 100), "exp": float64(time.Now().Unix() - 100)},
+		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100), "exp": float64(time.Now().Unix() - 100)},
 		false,
 		jwt.ValidationErrorNotValidYet | jwt.ValidationErrorExpired,
 		nil,
@@ -71,7 +75,7 @@ var jwtTestData = []struct {
 		"basic invalid",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.EhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar"},
+		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorSignatureInvalid,
 		nil,
@@ -80,7 +84,7 @@ var jwtTestData = []struct {
 		"basic nokeyfunc",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
 		nilKeyFunc,
-		map[string]interface{}{"foo": "bar"},
+		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorUnverifiable,
 		nil,
@@ -89,7 +93,7 @@ var jwtTestData = []struct {
 		"basic nokey",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
 		emptyKeyFunc,
-		map[string]interface{}{"foo": "bar"},
+		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorSignatureInvalid,
 		nil,
@@ -98,7 +102,7 @@ var jwtTestData = []struct {
 		"basic errorkey",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
 		errorKeyFunc,
-		map[string]interface{}{"foo": "bar"},
+		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorUnverifiable,
 		nil,
@@ -107,7 +111,7 @@ var jwtTestData = []struct {
 		"invalid signing method",
 		"",
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar"},
+		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorSignatureInvalid,
 		&jwt.Parser{ValidMethods: []string{"HS256"}},
@@ -116,7 +120,7 @@ var jwtTestData = []struct {
 		"valid signing method",
 		"",
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar"},
+		jwt.MapClaims{"foo": "bar"},
 		true,
 		0,
 		&jwt.Parser{ValidMethods: []string{"RS256", "HS256"}},
@@ -125,7 +129,18 @@ var jwtTestData = []struct {
 		"JSON Number",
 		"",
 		defaultKeyFunc,
-		map[string]interface{}{"foo": json.Number("123.4")},
+		jwt.MapClaims{"foo": json.Number("123.4")},
+		true,
+		0,
+		&jwt.Parser{UseJSONNumber: true},
+	},
+	{
+		"Standard Claims",
+		"",
+		defaultKeyFunc,
+		&jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(time.Second * 10).Unix(),
+		},
 		true,
 		0,
 		&jwt.Parser{UseJSONNumber: true},
@@ -134,7 +149,7 @@ var jwtTestData = []struct {
 		"JSON Number - basic expired",
 		"", // autogen
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar", "exp": json.Number(fmt.Sprintf("%v", time.Now().Unix()-100))},
+		jwt.MapClaims{"foo": "bar", "exp": json.Number(fmt.Sprintf("%v", time.Now().Unix()-100))},
 		false,
 		jwt.ValidationErrorExpired,
 		&jwt.Parser{UseJSONNumber: true},
@@ -143,7 +158,7 @@ var jwtTestData = []struct {
 		"JSON Number - basic nbf",
 		"", // autogen
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100))},
+		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100))},
 		false,
 		jwt.ValidationErrorNotValidYet,
 		&jwt.Parser{UseJSONNumber: true},
@@ -152,60 +167,55 @@ var jwtTestData = []struct {
 		"JSON Number - expired and nbf",
 		"", // autogen
 		defaultKeyFunc,
-		map[string]interface{}{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100)), "exp": json.Number(fmt.Sprintf("%v", time.Now().Unix()-100))},
+		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100)), "exp": json.Number(fmt.Sprintf("%v", time.Now().Unix()-100))},
 		false,
 		jwt.ValidationErrorNotValidYet | jwt.ValidationErrorExpired,
 		&jwt.Parser{UseJSONNumber: true},
 	},
 }
 
-func init() {
-	var e error
-	if jwtTestDefaultKey, e = ioutil.ReadFile("test/sample_key.pub"); e != nil {
-		panic(e)
-	}
-}
-
-func makeSample(c map[string]interface{}) string {
-	key, e := ioutil.ReadFile("test/sample_key")
-	if e != nil {
-		panic(e.Error())
-	}
-
-	token := jwt.New(jwt.SigningMethodRS256)
-	token.Claims = c
-	s, e := token.SignedString(key)
-
-	if e != nil {
-		panic(e.Error())
-	}
-
-	return s
-}
-
 func TestParser_Parse(t *testing.T) {
+	privateKey := test.LoadRSAPrivateKeyFromDisk("test/sample_key")
+
+	// Iterate over test data set and run tests
 	for _, data := range jwtTestData {
+		// If the token string is blank, use helper function to generate string
 		if data.tokenString == "" {
-			data.tokenString = makeSample(data.claims)
+			data.tokenString = test.MakeSampleToken(data.claims, privateKey)
 		}
 
+		// Parse the token
 		var token *jwt.Token
 		var err error
-		if data.parser != nil {
-			token, err = data.parser.Parse(data.tokenString, data.keyfunc)
-		} else {
-			token, err = jwt.Parse(data.tokenString, data.keyfunc)
+		var parser = data.parser
+		if parser == nil {
+			parser = new(jwt.Parser)
+		}
+		// Figure out correct claims type
+		switch data.claims.(type) {
+		case jwt.MapClaims:
+			token, err = parser.ParseWithClaims(data.tokenString, jwt.MapClaims{}, data.keyfunc)
+		case *jwt.StandardClaims:
+			token, err = parser.ParseWithClaims(data.tokenString, &jwt.StandardClaims{}, data.keyfunc)
 		}
 
+		// Verify result matches expectation
 		if !reflect.DeepEqual(data.claims, token.Claims) {
 			t.Errorf("[%v] Claims mismatch. Expecting: %v  Got: %v", data.name, data.claims, token.Claims)
 		}
+
 		if data.valid && err != nil {
 			t.Errorf("[%v] Error while verifying token: %T:%v", data.name, err, err)
 		}
+
 		if !data.valid && err == nil {
 			t.Errorf("[%v] Invalid token passed validation", data.name)
 		}
+
+		if (err == nil && !token.Valid) || (err != nil && token.Valid) {
+			t.Errorf("[%v] Inconsistent behavior between returned error and token.Valid")
+		}
+
 		if data.errors != 0 {
 			if err == nil {
 				t.Errorf("[%v] Expecting error.  Didn't get one.", data.name)
@@ -224,39 +234,6 @@ func TestParser_Parse(t *testing.T) {
 		}
 		if data.valid && token.Signature == "" {
 			t.Errorf("[%v] Signature is left unpopulated after parsing", data.name)
-		}
-	}
-}
-
-func TestParseRequest(t *testing.T) {
-	// Bearer token request
-	for _, data := range jwtTestData {
-		// FIXME: custom parsers are not supported by this helper.  skip tests that require them
-		if data.parser != nil {
-			t.Logf("Skipping [%v].  Custom parsers are not supported by ParseRequest", data.name)
-			continue
-		}
-
-		if data.tokenString == "" {
-			data.tokenString = makeSample(data.claims)
-		}
-
-		r, _ := http.NewRequest("GET", "/", nil)
-		r.Header.Set("Authorization", fmt.Sprintf("Bearer %v", data.tokenString))
-		token, err := jwt.ParseFromRequest(r, data.keyfunc)
-
-		if token == nil {
-			t.Errorf("[%v] Token was not found: %v", data.name, err)
-			continue
-		}
-		if !reflect.DeepEqual(data.claims, token.Claims) {
-			t.Errorf("[%v] Claims mismatch. Expecting: %v  Got: %v", data.name, data.claims, token.Claims)
-		}
-		if data.valid && err != nil {
-			t.Errorf("[%v] Error while verifying token: %v", data.name, err)
-		}
-		if !data.valid && err == nil {
-			t.Errorf("[%v] Invalid token passed validation", data.name)
 		}
 	}
 }

--- a/vendor/github.com/dgrijalva/jwt-go/request/doc.go
+++ b/vendor/github.com/dgrijalva/jwt-go/request/doc.go
@@ -1,0 +1,7 @@
+// Utility package for extracting JWT tokens from
+// HTTP requests.
+//
+// The main function is ParseFromRequest and it's WithClaims variant.
+// See examples for how to use the various Extractor implementations
+// or roll your own.
+package request

--- a/vendor/github.com/dgrijalva/jwt-go/request/extractor.go
+++ b/vendor/github.com/dgrijalva/jwt-go/request/extractor.go
@@ -1,0 +1,81 @@
+package request
+
+import (
+	"errors"
+	"net/http"
+)
+
+// Errors
+var (
+	ErrNoTokenInRequest = errors.New("no token present in request")
+)
+
+// Interface for extracting a token from an HTTP request.
+// The ExtractToken method should return a token string or an error.
+// If no token is present, you must return ErrNoTokenInRequest.
+type Extractor interface {
+	ExtractToken(*http.Request) (string, error)
+}
+
+// Extractor for finding a token in a header.  Looks at each specified
+// header in order until there's a match
+type HeaderExtractor []string
+
+func (e HeaderExtractor) ExtractToken(req *http.Request) (string, error) {
+	// loop over header names and return the first one that contains data
+	for _, header := range e {
+		if ah := req.Header.Get(header); ah != "" {
+			return ah, nil
+		}
+	}
+	return "", ErrNoTokenInRequest
+}
+
+// Extract token from request arguments.  This includes a POSTed form or
+// GET URL arguments.  Argument names are tried in order until there's a match.
+// This extractor calls `ParseMultipartForm` on the request
+type ArgumentExtractor []string
+
+func (e ArgumentExtractor) ExtractToken(req *http.Request) (string, error) {
+	// Make sure form is parsed
+	req.ParseMultipartForm(10e6)
+
+	// loop over arg names and return the first one that contains data
+	for _, arg := range e {
+		if ah := req.Form.Get(arg); ah != "" {
+			return ah, nil
+		}
+	}
+
+	return "", ErrNoTokenInRequest
+}
+
+// Tries Extractors in order until one returns a token string or an error occurs
+type MultiExtractor []Extractor
+
+func (e MultiExtractor) ExtractToken(req *http.Request) (string, error) {
+	// loop over header names and return the first one that contains data
+	for _, extractor := range e {
+		if tok, err := extractor.ExtractToken(req); tok != "" {
+			return tok, nil
+		} else if err != ErrNoTokenInRequest {
+			return "", err
+		}
+	}
+	return "", ErrNoTokenInRequest
+}
+
+// Wrap an Extractor in this to post-process the value before it's handed off.
+// See AuthorizationHeaderExtractor for an example
+type PostExtractionFilter struct {
+	Extractor
+	Filter func(string) (string, error)
+}
+
+func (e *PostExtractionFilter) ExtractToken(req *http.Request) (string, error) {
+	if tok, err := e.Extractor.ExtractToken(req); tok != "" {
+		return e.Filter(tok)
+	} else {
+		return "", err
+	}
+}

--- a/vendor/github.com/dgrijalva/jwt-go/request/extractor_example_test.go
+++ b/vendor/github.com/dgrijalva/jwt-go/request/extractor_example_test.go
@@ -1,0 +1,32 @@
+package request
+
+import (
+	"fmt"
+	"net/url"
+)
+
+const (
+	exampleTokenA = "A"
+)
+
+func ExampleHeaderExtractor() {
+	req := makeExampleRequest("GET", "/", map[string]string{"Token": exampleTokenA}, nil)
+	tokenString, err := HeaderExtractor{"Token"}.ExtractToken(req)
+	if err == nil {
+		fmt.Println(tokenString)
+	} else {
+		fmt.Println(err)
+	}
+	//Output: A
+}
+
+func ExampleArgumentExtractor() {
+	req := makeExampleRequest("GET", "/", nil, url.Values{"token": {extractorTestTokenA}})
+	tokenString, err := ArgumentExtractor{"token"}.ExtractToken(req)
+	if err == nil {
+		fmt.Println(tokenString)
+	} else {
+		fmt.Println(err)
+	}
+	//Output: A
+}

--- a/vendor/github.com/dgrijalva/jwt-go/request/extractor_test.go
+++ b/vendor/github.com/dgrijalva/jwt-go/request/extractor_test.go
@@ -1,0 +1,91 @@
+package request
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+var extractorTestTokenA = "A"
+var extractorTestTokenB = "B"
+
+var extractorTestData = []struct {
+	name      string
+	extractor Extractor
+	headers   map[string]string
+	query     url.Values
+	token     string
+	err       error
+}{
+	{
+		name:      "simple header",
+		extractor: HeaderExtractor{"Foo"},
+		headers:   map[string]string{"Foo": extractorTestTokenA},
+		query:     nil,
+		token:     extractorTestTokenA,
+		err:       nil,
+	},
+	{
+		name:      "simple argument",
+		extractor: ArgumentExtractor{"token"},
+		headers:   map[string]string{},
+		query:     url.Values{"token": {extractorTestTokenA}},
+		token:     extractorTestTokenA,
+		err:       nil,
+	},
+	{
+		name: "multiple extractors",
+		extractor: MultiExtractor{
+			HeaderExtractor{"Foo"},
+			ArgumentExtractor{"token"},
+		},
+		headers: map[string]string{"Foo": extractorTestTokenA},
+		query:   url.Values{"token": {extractorTestTokenB}},
+		token:   extractorTestTokenA,
+		err:     nil,
+	},
+	{
+		name:      "simple miss",
+		extractor: HeaderExtractor{"This-Header-Is-Not-Set"},
+		headers:   map[string]string{"Foo": extractorTestTokenA},
+		query:     nil,
+		token:     "",
+		err:       ErrNoTokenInRequest,
+	},
+	{
+		name:      "filter",
+		extractor: AuthorizationHeaderExtractor,
+		headers:   map[string]string{"Authorization": "Bearer " + extractorTestTokenA},
+		query:     nil,
+		token:     extractorTestTokenA,
+		err:       nil,
+	},
+}
+
+func TestExtractor(t *testing.T) {
+	// Bearer token request
+	for _, data := range extractorTestData {
+		// Make request from test struct
+		r := makeExampleRequest("GET", "/", data.headers, data.query)
+
+		// Test extractor
+		token, err := data.extractor.ExtractToken(r)
+		if token != data.token {
+			t.Errorf("[%v] Expected token '%v'.  Got '%v'", data.name, data.token, token)
+			continue
+		}
+		if err != data.err {
+			t.Errorf("[%v] Expected error '%v'.  Got '%v'", data.name, data.err, err)
+			continue
+		}
+	}
+}
+
+func makeExampleRequest(method, path string, headers map[string]string, urlArgs url.Values) *http.Request {
+	r, _ := http.NewRequest(method, fmt.Sprintf("%v?%v", path, urlArgs.Encode()), nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}

--- a/vendor/github.com/dgrijalva/jwt-go/request/oauth2.go
+++ b/vendor/github.com/dgrijalva/jwt-go/request/oauth2.go
@@ -1,0 +1,28 @@
+package request
+
+import (
+	"strings"
+)
+
+// Strips 'Bearer ' prefix from bearer token string
+func stripBearerPrefixFromTokenString(tok string) (string, error) {
+	// Should be a bearer token
+	if len(tok) > 6 && strings.ToUpper(tok[0:7]) == "BEARER " {
+		return tok[7:], nil
+	}
+	return tok, nil
+}
+
+// Extract bearer token from Authorization header
+// Uses PostExtractionFilter to strip "Bearer " prefix from header
+var AuthorizationHeaderExtractor = &PostExtractionFilter{
+	HeaderExtractor{"Authorization"},
+	stripBearerPrefixFromTokenString,
+}
+
+// Extractor for OAuth2 access tokens.  Looks in 'Authorization'
+// header then 'access_token' argument for a token.
+var OAuth2Extractor = &MultiExtractor{
+	AuthorizationHeaderExtractor,
+	ArgumentExtractor{"access_token"},
+}

--- a/vendor/github.com/dgrijalva/jwt-go/request/request.go
+++ b/vendor/github.com/dgrijalva/jwt-go/request/request.go
@@ -1,0 +1,24 @@
+package request
+
+import (
+	"github.com/dgrijalva/jwt-go"
+	"net/http"
+)
+
+// Extract and parse a JWT token from an HTTP request.
+// This behaves the same as Parse, but accepts a request and an extractor
+// instead of a token string.  The Extractor interface allows you to define
+// the logic for extracting a token.  Several useful implementations are provided.
+func ParseFromRequest(req *http.Request, extractor Extractor, keyFunc jwt.Keyfunc) (token *jwt.Token, err error) {
+	return ParseFromRequestWithClaims(req, extractor, jwt.MapClaims{}, keyFunc)
+}
+
+// ParseFromRequest but with custom Claims type
+func ParseFromRequestWithClaims(req *http.Request, extractor Extractor, claims jwt.Claims, keyFunc jwt.Keyfunc) (token *jwt.Token, err error) {
+	// Extract token from request
+	if tokStr, err := extractor.ExtractToken(req); err == nil {
+		return jwt.ParseWithClaims(tokStr, claims, keyFunc)
+	} else {
+		return nil, err
+	}
+}

--- a/vendor/github.com/dgrijalva/jwt-go/request/request_test.go
+++ b/vendor/github.com/dgrijalva/jwt-go/request/request_test.go
@@ -1,0 +1,103 @@
+package request
+
+import (
+	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go/test"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+var requestTestData = []struct {
+	name      string
+	claims    jwt.MapClaims
+	extractor Extractor
+	headers   map[string]string
+	query     url.Values
+	valid     bool
+}{
+	{
+		"authorization bearer token",
+		jwt.MapClaims{"foo": "bar"},
+		AuthorizationHeaderExtractor,
+		map[string]string{"Authorization": "Bearer %v"},
+		url.Values{},
+		true,
+	},
+	{
+		"oauth bearer token - header",
+		jwt.MapClaims{"foo": "bar"},
+		OAuth2Extractor,
+		map[string]string{"Authorization": "Bearer %v"},
+		url.Values{},
+		true,
+	},
+	{
+		"oauth bearer token - url",
+		jwt.MapClaims{"foo": "bar"},
+		OAuth2Extractor,
+		map[string]string{},
+		url.Values{"access_token": {"%v"}},
+		true,
+	},
+	{
+		"url token",
+		jwt.MapClaims{"foo": "bar"},
+		ArgumentExtractor{"token"},
+		map[string]string{},
+		url.Values{"token": {"%v"}},
+		true,
+	},
+}
+
+func TestParseRequest(t *testing.T) {
+	// load keys from disk
+	privateKey := test.LoadRSAPrivateKeyFromDisk("../test/sample_key")
+	publicKey := test.LoadRSAPublicKeyFromDisk("../test/sample_key.pub")
+	keyfunc := func(*jwt.Token) (interface{}, error) {
+		return publicKey, nil
+	}
+
+	// Bearer token request
+	for _, data := range requestTestData {
+		// Make token from claims
+		tokenString := test.MakeSampleToken(data.claims, privateKey)
+
+		// Make query string
+		for k, vv := range data.query {
+			for i, v := range vv {
+				if strings.Contains(v, "%v") {
+					data.query[k][i] = fmt.Sprintf(v, tokenString)
+				}
+			}
+		}
+
+		// Make request from test struct
+		r, _ := http.NewRequest("GET", fmt.Sprintf("/?%v", data.query.Encode()), nil)
+		for k, v := range data.headers {
+			if strings.Contains(v, "%v") {
+				r.Header.Set(k, fmt.Sprintf(v, tokenString))
+			} else {
+				r.Header.Set(k, tokenString)
+			}
+		}
+		token, err := ParseFromRequestWithClaims(r, data.extractor, jwt.MapClaims{}, keyfunc)
+
+		if token == nil {
+			t.Errorf("[%v] Token was not found: %v", data.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(data.claims, token.Claims) {
+			t.Errorf("[%v] Claims mismatch. Expecting: %v  Got: %v", data.name, data.claims, token.Claims)
+		}
+		if data.valid && err != nil {
+			t.Errorf("[%v] Error while verifying token: %v", data.name, err)
+		}
+		if !data.valid && err == nil {
+			t.Errorf("[%v] Invalid token passed validation", data.name)
+		}
+	}
+}

--- a/vendor/github.com/dgrijalva/jwt-go/rsa.go
+++ b/vendor/github.com/dgrijalva/jwt-go/rsa.go
@@ -44,8 +44,7 @@ func (m *SigningMethodRSA) Alg() string {
 }
 
 // Implements the Verify method from SigningMethod
-// For this signing method, must be either a PEM encoded PKCS1 or PKCS8 RSA public key as
-// []byte, or an rsa.PublicKey structure.
+// For this signing method, must be an rsa.PublicKey structure.
 func (m *SigningMethodRSA) Verify(signingString, signature string, key interface{}) error {
 	var err error
 
@@ -56,16 +55,10 @@ func (m *SigningMethodRSA) Verify(signingString, signature string, key interface
 	}
 
 	var rsaKey *rsa.PublicKey
+	var ok bool
 
-	switch k := key.(type) {
-	case []byte:
-		if rsaKey, err = ParseRSAPublicKeyFromPEM(k); err != nil {
-			return err
-		}
-	case *rsa.PublicKey:
-		rsaKey = k
-	default:
-		return ErrInvalidKey
+	if rsaKey, ok = key.(*rsa.PublicKey); !ok {
+		return ErrInvalidKeyType
 	}
 
 	// Create hasher
@@ -80,20 +73,13 @@ func (m *SigningMethodRSA) Verify(signingString, signature string, key interface
 }
 
 // Implements the Sign method from SigningMethod
-// For this signing method, must be either a PEM encoded PKCS1 or PKCS8 RSA private key as
-// []byte, or an rsa.PrivateKey structure.
+// For this signing method, must be an rsa.PrivateKey structure.
 func (m *SigningMethodRSA) Sign(signingString string, key interface{}) (string, error) {
-	var err error
 	var rsaKey *rsa.PrivateKey
+	var ok bool
 
-	switch k := key.(type) {
-	case []byte:
-		if rsaKey, err = ParseRSAPrivateKeyFromPEM(k); err != nil {
-			return "", err
-		}
-	case *rsa.PrivateKey:
-		rsaKey = k
-	default:
+	// Validate type of key
+	if rsaKey, ok = key.(*rsa.PrivateKey); !ok {
 		return "", ErrInvalidKey
 	}
 

--- a/vendor/github.com/dgrijalva/jwt-go/rsa_pss.go
+++ b/vendor/github.com/dgrijalva/jwt-go/rsa_pss.go
@@ -106,7 +106,7 @@ func (m *SigningMethodRSAPSS) Sign(signingString string, key interface{}) (strin
 	case *rsa.PrivateKey:
 		rsaKey = k
 	default:
-		return "", ErrInvalidKey
+		return "", ErrInvalidKeyType
 	}
 
 	// Create the hasher

--- a/vendor/github.com/dgrijalva/jwt-go/rsa_test.go
+++ b/vendor/github.com/dgrijalva/jwt-go/rsa_test.go
@@ -45,7 +45,8 @@ var rsaTestData = []struct {
 }
 
 func TestRSAVerify(t *testing.T) {
-	key, _ := ioutil.ReadFile("test/sample_key.pub")
+	keyData, _ := ioutil.ReadFile("test/sample_key.pub")
+	key, _ := jwt.ParseRSAPublicKeyFromPEM(keyData)
 
 	for _, data := range rsaTestData {
 		parts := strings.Split(data.tokenString, ".")
@@ -62,7 +63,8 @@ func TestRSAVerify(t *testing.T) {
 }
 
 func TestRSASign(t *testing.T) {
-	key, _ := ioutil.ReadFile("test/sample_key")
+	keyData, _ := ioutil.ReadFile("test/sample_key")
+	key, _ := jwt.ParseRSAPrivateKeyFromPEM(keyData)
 
 	for _, data := range rsaTestData {
 		if data.valid {

--- a/vendor/github.com/dgrijalva/jwt-go/test/helpers.go
+++ b/vendor/github.com/dgrijalva/jwt-go/test/helpers.go
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"crypto/rsa"
+	"github.com/dgrijalva/jwt-go"
+	"io/ioutil"
+)
+
+func LoadRSAPrivateKeyFromDisk(location string) *rsa.PrivateKey {
+	keyData, e := ioutil.ReadFile(location)
+	if e != nil {
+		panic(e.Error())
+	}
+	key, e := jwt.ParseRSAPrivateKeyFromPEM(keyData)
+	if e != nil {
+		panic(e.Error())
+	}
+	return key
+}
+
+func LoadRSAPublicKeyFromDisk(location string) *rsa.PublicKey {
+	keyData, e := ioutil.ReadFile(location)
+	if e != nil {
+		panic(e.Error())
+	}
+	key, e := jwt.ParseRSAPublicKeyFromPEM(keyData)
+	if e != nil {
+		panic(e.Error())
+	}
+	return key
+}
+
+func MakeSampleToken(c jwt.Claims, key interface{}) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, c)
+	s, e := token.SignedString(key)
+
+	if e != nil {
+		panic(e.Error())
+	}
+
+	return s
+}

--- a/vendor/github.com/dgrijalva/jwt-go/token.go
+++ b/vendor/github.com/dgrijalva/jwt-go/token.go
@@ -3,7 +3,6 @@ package jwt
 import (
 	"encoding/base64"
 	"encoding/json"
-	"net/http"
 	"strings"
 	"time"
 )
@@ -25,19 +24,23 @@ type Token struct {
 	Raw       string                 // The raw token.  Populated when you Parse a token
 	Method    SigningMethod          // The signing method used or to be used
 	Header    map[string]interface{} // The first segment of the token
-	Claims    map[string]interface{} // The second segment of the token
+	Claims    Claims                 // The second segment of the token
 	Signature string                 // The third segment of the token.  Populated when you Parse a token
 	Valid     bool                   // Is the token valid?  Populated when you Parse/Verify a token
 }
 
 // Create a new Token.  Takes a signing method
 func New(method SigningMethod) *Token {
+	return NewWithClaims(method, MapClaims{})
+}
+
+func NewWithClaims(method SigningMethod, claims Claims) *Token {
 	return &Token{
 		Header: map[string]interface{}{
 			"typ": "JWT",
 			"alg": method.Alg(),
 		},
-		Claims: make(map[string]interface{}),
+		Claims: claims,
 		Method: method,
 	}
 }
@@ -63,16 +66,15 @@ func (t *Token) SigningString() (string, error) {
 	var err error
 	parts := make([]string, 2)
 	for i, _ := range parts {
-		var source map[string]interface{}
-		if i == 0 {
-			source = t.Header
-		} else {
-			source = t.Claims
-		}
-
 		var jsonValue []byte
-		if jsonValue, err = json.Marshal(source); err != nil {
-			return "", err
+		if i == 0 {
+			if jsonValue, err = json.Marshal(t.Header); err != nil {
+				return "", err
+			}
+		} else {
+			if jsonValue, err = json.Marshal(t.Claims); err != nil {
+				return "", err
+			}
 		}
 
 		parts[i] = EncodeSegment(jsonValue)
@@ -87,28 +89,8 @@ func Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 	return new(Parser).Parse(tokenString, keyFunc)
 }
 
-// Try to find the token in an http.Request.
-// This method will call ParseMultipartForm if there's no token in the header.
-// Currently, it looks in the Authorization header as well as
-// looking for an 'access_token' request parameter in req.Form.
-func ParseFromRequest(req *http.Request, keyFunc Keyfunc) (token *Token, err error) {
-
-	// Look for an Authorization header
-	if ah := req.Header.Get("Authorization"); ah != "" {
-		// Should be a bearer token
-		if len(ah) > 6 && strings.ToUpper(ah[0:7]) == "BEARER " {
-			return Parse(ah[7:], keyFunc)
-		}
-	}
-
-	// Look for "access_token" parameter
-	req.ParseMultipartForm(10e6)
-	if tokStr := req.Form.Get("access_token"); tokStr != "" {
-		return Parse(tokStr, keyFunc)
-	}
-
-	return nil, ErrNoTokenInRequest
-
+func ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
+	return new(Parser).ParseWithClaims(tokenString, claims, keyFunc)
 }
 
 // Encode JWT specific base64url encoding with padding stripped


### PR DESCRIPTION
```
./server.go:22: invalid operation: token.Claims["name"] (type jwt.Claims does not support indexing)
./server.go:23: invalid operation: token.Claims["admin"] (type jwt.Claims does not support indexing)
./server.go:24: invalid operation: token.Claims["exp"] (type jwt.Claims does not support indexing)
./server.go:45: invalid operation: user.Claims["name"] (type jwt.Claims does not support indexing)
```
Fix previous error when using an updated version of JWT lib v3.