### PR TITLE
Fix typo gzip middleware

### DIFF
--- a/website/content/middleware/gzip.md
+++ b/website/content/middleware/gzip.md
@@ -39,6 +39,6 @@ DefaultGzipConfig = GzipConfig{
 ```go
 e := echo.New()
 e.Use(middleware.GzipWithConfig(middleware.GzipConfig{
-  Level: 5
+  Level: 5,
 }))
 ```


### PR DESCRIPTION
Missing ',' before newline in composite literal