### PR TITLE
Update .travis.yml - Use 1.9.x and 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.7.x
-  - 1.8.x
+  - 1.9.x
+  - 1.10.x
   - tip
 install:
   - make dependency


### PR DESCRIPTION
- Removes 1.7.x and 1.8.x
- Introduces 1.9.x and 1.10.x

Currently the travis jobs for 1.7.x fail, because dep is using functions introduced in go 1.8.x

```
$ make dependency
go get -u github.com/golang/dep/cmd/dep
# github.com/golang/dep/gps
../../golang/dep/gps/constraint.go:378: undefined: sort.SliceStable
../../golang/dep/gps/lock.go:31: undefined: sort.SliceIsSorted
../../golang/dep/gps/lock.go:38: undefined: sort.Slice
```

Motivation behind the new versions is the .travis.yml configuration in the echo Repository.
See: https://github.com/labstack/echo/blob/master/.travis.yml