### PR TITLE
Fix varibale name in casbin docs

### DIFF
--- a/website/content/middleware/casbin-auth.md
+++ b/website/content/middleware/casbin-auth.md
@@ -34,7 +34,7 @@ import (
 
 ```go
 e := echo.New()
-e.Use(casbin-mw.Middleware(casbin.NewEnforcer("casbin_auth_model.conf", "casbin_auth_policy.csv")))
+e.Use(casbin_mw.Middleware(casbin.NewEnforcer("casbin_auth_model.conf", "casbin_auth_policy.csv")))
 ```
 
 For syntax, see: [Model.md](https://github.com/casbin/casbin/blob/master/Model.md).
@@ -49,7 +49,7 @@ e := echo.New()
 ce := casbin.NewEnforcer("casbin_auth_model.conf", "")
 ce.AddRoleForUser("alice", "admin")
 ce.AddPolicy(...)
-e.Use(casbin_mw.MiddlewareWithConfig(casbin-mw.Config(
+e.Use(casbin_mw.MiddlewareWithConfig(casbin_mw.Config(
   Enforcer: ce,
 )))
 ```

--- a/website/content/middleware/casbin-auth.md
+++ b/website/content/middleware/casbin-auth.md
@@ -19,14 +19,14 @@ description = "Casbin Auth middleware for Echo. It supports access control model
 - RESTful
 - Deny-override: both allow and deny authorizations are supported, deny overrides the allow.
 
-> Echo community contribution 
+> Echo community contribution
 
 ## Dependencies
 
 ```go
 import (
   "github.com/casbin/casbin"
-  casbin_mw "github.com/labstack/echo-contrib/casbin" 
+  casbin_mw "github.com/labstack/echo-contrib/casbin"
 )
 ```
 


### PR DESCRIPTION
Hi, thank you very much for this awesome software! :)

The current version of the docs mixes `casbin_mw` and `casbin-mw`. I replaced the latter with `casbin_mw`.

The second commit removes some trailing whitespace. (I hope it is okay to commit this without an additional PR.)