### PR TITLE
Do not firewall alerts when rebooting echo server at every time

### DIFF
--- a/website/content/guide.md
+++ b/website/content/guide.md
@@ -35,7 +35,7 @@ func main() {
 	e.GET("/", func(c echo.Context) error {
 		return c.String(http.StatusOK, "Hello, World!")
 	})
-	e.Logger.Fatal(e.Start(":1323"))
+	e.Logger.Fatal(e.Start("localhost:1323"))
 }
 ```
 


### PR DESCRIPTION
Hello.
I ran `go run server.go` exactly as stated in the guide, but I get a firewall notification every time I ran it. This is annoying.
So I suggest you change the guide to avoid notifications.
(I tested on Windows 10.)
