### PR TITLE
Fix the first published year of copyright

### DIFF
--- a/website/layouts/partials/footer.html
+++ b/website/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 <footer class="w3-content w3-container w3-padding-48 w3-center footer">
   <p>
-    <strong>Echo</strong> by <a href="https://labstack.com">LabStack</a> © 2018 LabStack
+    <strong>Echo</strong> by <a href="https://labstack.com">LabStack</a> © 2015 LabStack
   </p>
   <p>
     <a class="icon" href="https://labstack.com/blog">


### PR DESCRIPTION
Copyright notice must contains the year ***in which the work was first published***, not last updated.

https://en.wikipedia.org/wiki/Copyright_notice#Technical_requirements

2015 is [when first tag is created](https://github.com/labstack/echo/releases?after=v0.0.10).
You might change it.