### PR TITLE
Use buffered channel for graceful shutdown

### DIFF
--- a/cookbook/graceful-shutdown/server.go
+++ b/cookbook/graceful-shutdown/server.go
@@ -27,8 +27,8 @@ func main() {
 		}
 	}()
 
-	// Wait for interrupt signal to gracefully shutdown the server with
-	// a timeout of 10 seconds.
+	// Wait for interrupt signal to gracefully shutdown the server with a timeout of 10 seconds. 
+	// Use a buffered channel to avoid missing signals as recommended for signal.Notify
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 	<-quit

--- a/cookbook/graceful-shutdown/server.go
+++ b/cookbook/graceful-shutdown/server.go
@@ -29,7 +29,7 @@ func main() {
 
 	// Wait for interrupt signal to gracefully shutdown the server with
 	// a timeout of 10 seconds.
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 	<-quit
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
Hi, this is a trivial fix. According to https://golang.org/pkg/os/signal/#example_Notify buffered channel should be used to avoid missing signal. Thought we should include that in the doc. Thanks.