### PR TITLE
Use single encoder for streaming response.

### DIFF
--- a/cookbook/streaming-response/server.go
+++ b/cookbook/streaming-response/server.go
@@ -31,8 +31,10 @@ func main() {
 	e.GET("/", func(c echo.Context) error {
 		c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 		c.Response().WriteHeader(http.StatusOK)
+
+		enc := json.NewEncoder(c.Response())
 		for _, l := range locations {
-			if err := json.NewEncoder(c.Response()).Encode(l); err != nil {
+			if err := enc.Encode(l); err != nil {
 				return err
 			}
 			c.Response().Flush()


### PR DESCRIPTION
If I'm not misunderstood there should be no need to create new encoder on each iteration of for loop.  