### PR TITLE
Use constant time comparison in basic auth example

### DIFF
--- a/website/content/middleware/basic-auth.md
+++ b/website/content/middleware/basic-auth.md
@@ -15,7 +15,9 @@ Basic auth middleware provides an HTTP basic authentication.
 
 ```go
 e.Use(middleware.BasicAuth(func(username, password string, c echo.Context) (bool, error) {
-	if username == "joe" && password == "secret" {
+	// Be careful to use constant time comparison to prevent timing attacks
+	if subtle.ConstantTimeCompare([]byte(username), []byte("joe")) == 1 &&
+		subtle.ConstantTimeCompare([]byte(password), []byte("secret")) == 1 {
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
The current example is vulnerable to timing attacks. This change suggests the security best-practice of constant time comparison.