### PR TITLE
Explain middleware `Use()` required ordering

### DIFF
--- a/website/content/middleware.md
+++ b/website/content/middleware.md
@@ -17,6 +17,9 @@ every request or limiting the number of requests.
 
 Handler is processed in the end after all middleware are finished executing.
 
+Middleware registed using `Echo#Use()` is only executed for paths which are 
+registered after `Echo#Use()` has been called.
+
 ## Levels
 
 ### Root Level (Before router)


### PR DESCRIPTION
This addition explains how `Echo#Use()` must be called in order for the middleware to be executed. Previous issues (https://github.com/labstack/echo/issues/1304) have referenced this and the explanation has been to look at the unit tests. Having the behavior documented will help users understand how to correctly use this part of the library.