### PR TITLE
fix echo version while importing to prevent an error

### DIFF
--- a/website/content/guide.md
+++ b/website/content/guide.md
@@ -27,7 +27,7 @@ package main
 import (
 	"net/http"
 	
-	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo"
 )
 
 func main() {


### PR DESCRIPTION
If you install echo with this guide with:
`$ go get -u github.com/labstack/echo/...`
and after that use import like this:
`import (
	...
	"github.com/labstack/echo/v4"
)`
you'll get an error:

>  cannot find package "github.com/labstack/echo/v4" in any of:
>         /usr/local/go/src/github.com/labstack/echo/v4 (from $GOROOT)
>         $GOPATH/src/github.com/labstack/echo/v4 (from $GOPATH)

we need to import just github.com/labstack/echo as we get v4 in fact (v4.1.14 at the moment)