### PR TITLE
Update request.md: improve validation error

### DIFF
--- a/website/content/guide/request.md
+++ b/website/content/guide/request.md
@@ -191,7 +191,7 @@ func main() {
 			return
 		}
 		if err = c.Validate(u); err != nil {
-			return
+			return c.String(http.StatusBadRequest, err.Error())
 		}
 		return c.JSON(http.StatusOK, u)
 	})


### PR DESCRIPTION
When c.Validate(u) returns an error, if we simply return the error up the stack, the user will see an "internal error" message.
Improve handling by returning the status http.StatusBadRequest with the validation failures in the string.