### PR TITLE
It does not work for me when using "v4"

### DIFF
--- a/website/content/guide.md
+++ b/website/content/guide.md
@@ -14,7 +14,7 @@ type = "guide"
 ### Installation
 
 ```sh
-$ go get github.com/labstack/echo/v4
+$ go get github.com/labstack/echo
 ```
 
 ### Hello, World!
@@ -27,7 +27,7 @@ package main
 import (
 	"net/http"
 	
-	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo"
 )
 
 func main() {


### PR DESCRIPTION
This is the reason why I removed it from the guide.

This is the message I was getting:

```
package github.com/labstack/echo/v4: cannot find package "github.com/labstack/echo/v4" in any of:
	/usr/lib/go-1.13/src/github.com/labstack/echo/v4 (from $GOROOT)
	/home/junior/go/src/github.com/labstack/echo/v4 (from $GOPATH)
```