### PR TITLE
Update request.md

### DIFF
--- a/website/content/guide/request.md
+++ b/website/content/guide/request.md
@@ -179,7 +179,7 @@ type (
 )
 
 func (cv *CustomValidator) Validate(i interface{}) error {
-	return echo.NewHTTPError(http.StatusInternalServerError, cv.validator.Struct(i).Error())
+	return cv.validator.Struct(i)
 }
 
 func main() {
@@ -187,10 +187,10 @@ func main() {
 	e.Validator = &CustomValidator{validator: validator.New()}
 	e.POST("/users", func(c echo.Context) (err error) {
 		u := new(User)
-		if err = c.Bind(u); err != nil {
+		if err := c.Bind(u); err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
-		if err = c.Validate(u); err != nil {
+		if err := c.Validate(u); err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 		return c.JSON(http.StatusOK, u)


### PR DESCRIPTION
Example didn't work as is:

1. err variable wasn't properly defined using ':=' [forgot the colon]
2. a valid response resulted in a nil pointer dereference panic, because you were referencing a v.validator.Struct(i).Error() [Error() in this return was a nil, since no error was encountered]