### PR TITLE
Update Echo#Start error handling

### DIFF
--- a/cookbook/graceful-shutdown/server.go
+++ b/cookbook/graceful-shutdown/server.go
@@ -22,8 +22,8 @@ func main() {
 
 	// Start server
 	go func() {
-		if err := e.Start(":1323"); err != nil {
-			e.Logger.Info("shutting down the server")
+		if err := e.Start(":1323"); err != nil && err != http.ErrServerClosed {
+			e.Logger.Fatal("shutting down the server")
 		}
 	}()
 


### PR DESCRIPTION
When encountering an error on app start, `bind: address already in use` for example, the app won't quit and keep waiting on the exit channel for a signal.
Therefore, Logger.Info changed to Logger.Fatal.
In order to not quit immediately on SIGINT another condition added: err != http.ErrServerClosed