### PR TITLE
Fix segfault in example code

### DIFF
--- a/website/content/guide/request.md
+++ b/website/content/guide/request.md
@@ -96,7 +96,10 @@ type (
 )
 
 func (cv *CustomValidator) Validate(i interface{}) error {
-  return echo.NewHTTPError(http.StatusInternalServerError, cv.validator.Struct(i).Error())
+	if err := cv.validator.Struct(i); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return nil
 }
 
 func main() {


### PR DESCRIPTION
This change fixes a segfault which occurs in the validation example code. When the validated struct contains no errors `cv.validator.Struct(i)` returns nil. Calling `Error()` on this nil return value was causing the segfault.