### PR TITLE
warning about double slashes when defining group and routes

### DIFF
--- a/website/content/guide/routing.md
+++ b/website/content/guide/routing.md
@@ -92,6 +92,8 @@ g.Use(middleware.BasicAuth(func(username, password string, c echo.Context) (bool
 }))
 ```
 
+> Be aware of double slashes! For example group `/users/` and GET route `/:id` will create `/users//:id` route.
+
 ## Route Naming
 
 Each of the registration methods returns a `Route` object, which can be used to name a route after the registration. For example:


### PR DESCRIPTION
This is warning for users about double slashes when creating routes with group.  

Related issue https://github.com/labstack/echo/issues/1784#issue-812673706