### PR TITLE
Refactor graceful shutdown example to work better with returned errors and background processes handling

### DIFF
--- a/cookbook/graceful-shutdown/server.go
+++ b/cookbook/graceful-shutdown/server.go
@@ -12,29 +12,41 @@ import (
 )
 
 func main() {
-	// Setup
+	// start background processes or anything that needs to be opened/started out of Echo
+	// and before Echo starts serving requests
+
 	e := echo.New()
 	e.Logger.SetLevel(log.INFO)
+
 	e.GET("/", func(c echo.Context) error {
 		time.Sleep(5 * time.Second)
 		return c.JSON(http.StatusOK, "OK")
 	})
 
-	// Start server
-	go func() {
-		if err := e.Start(":1323"); err != nil && err != http.ErrServerClosed {
-			e.Logger.Fatal("shutting down the server")
-		}
-	}()
+	// Wait for interrupt signal to gracefully shutdown the server with a timeout of 10 seconds.
+	go mustGracefullyShutdown(e)
 
-	// Wait for interrupt signal to gracefully shutdown the server with a timeout of 10 seconds. 
-	// Use a buffered channel to avoid missing signals as recommended for signal.Notify
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt)
-	<-quit
+	// Start blocks until Echo finishes serving ongoing requests and shuts down or fails to start with an error
+	err := e.Start(":1323")
+	if err != nil && err != http.ErrServerClosed { // http.ErrServerClosed indicates normal Echo shutdown by e.Shutdown
+		e.Logger.Errorf("Shutting down the server due error: %v", err)
+	}
+
+	// stop background processes or anything that was opened/started out of Echo
+}
+
+func mustGracefullyShutdown(e *echo.Echo) {
+	var shutdownSig = make(chan os.Signal, 1)
+	signal.Notify(shutdownSig, os.Interrupt) // catch interrupt signal (ctrl+C)
+	<-shutdownSig
+
+	e.Logger.Info("Received shutdown signal. Starting gracefully to shut down Echo server")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err := e.Shutdown(ctx); err != nil {
-		e.Logger.Fatal(err)
+	if err := e.Shutdown(ctx); err == context.DeadlineExceeded {
+		// Fatal() terminates program with os.Exit(1)
+		// NB: this does not close anything cleanly
+		e.Logger.Fatal("Graceful shutdown timeout exceeded. Exiting program forcefully!")
 	}
 }


### PR DESCRIPTION
Reason to switching where server is started with signal waiting is that - with server we need to handle errors and sometimes do work with things that were opened/started before Echo started serving requests.  If that flow is in main flow (outside of goroutine) - it is easier to handle that as `e.Start()` is anyway blocking until server stops and steps we want to do are after that

also moved all graceful logic to method as it is then more copy/paste friendly

NB: this logic still kills program when timeout for graceful shutdown is exceeded