### PR TITLE
Fix template name in template.md

### DIFF
--- a/website/content/guide/templates.md
+++ b/website/content/guide/templates.md
@@ -51,7 +51,7 @@ Example below shows how to use Go `html/template`:
 
     ```go
     func Hello(c echo.Context) error {
-    	return c.Render(http.StatusOK, "hello.html", "World")
+    	return c.Render(http.StatusOK, "hello", "World")
     }
     ```
 


### PR DESCRIPTION
The output shows nothing due to the change #148.
If you prefer calling by file name, you can also fix by removing `{{define "hello"}}` `{{.}}!{{end}}`.