### PR TITLE
fix baseurl for https://echo.labstack.com/

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Build static pages
         run: |
-          export BASE_URL=https://$(echo $GITHUB_REPOSITORY | cut -f1 -d"/").github.io/echox/
+          export BASE_URL=https://echo.labstack.com/
           cd website
           hugo -D --baseURL $BASE_URL
 


### PR DESCRIPTION
after moving documentation hosting to githubpages and custom cname we need to change hugo base url to https://echo.labstack.com/guide/ or relative links will not work