### PR TITLE
Fix: Clarify limitations of custom context

### DIFF
--- a/website/content/guide/context.md
+++ b/website/content/guide/context.md
@@ -42,6 +42,8 @@ e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 
 > This middleware should be registered before any other middleware.
 
+> The custom context cannot be defined in a middleware before the router ran (Pre)
+
 **Use in handler**
 
 ```go


### PR DESCRIPTION
The router expects the Echo Context to be the internal type `*context` ([reference](https://github.com/labstack/echo/blob/v4.2.2/router.go#L341)), so it cannot be replaced by a custom context before that.

Currently, if you try to define the custom middleware before the router (via `Pre` method) the following panic will be raised:
```
echo: http: panic serving 172.23.0.1:49366: interface conversion: echo.Context is context.Context, not *echo.context
goroutine 8 [running]:
net/http.(*conn).serve.func1(0xc0001260a0)
	/usr/local/go/src/net/http/server.go:1824 +0x153
panic(0x803bc0, 0xc000114f90)
	/usr/local/go/src/runtime/panic.go:971 +0x499
github.com/labstack/echo/v4.(*Router).Find(0xc00000ea68, 0xc00002a260, 0x4, 0xc00002a265, 0xc, 0x8fc228, 0xc0000613e0)
	/go/pkg/mod/github.com/labstack/echo/v4@v4.2.2/router.go:341 +0x77e
```