### PR TITLE
Add page describing how to start (custom) HTTP(s) server with Echo

### DIFF
--- a/cookbook/auto-tls/server.go
+++ b/cookbook/auto-tls/server.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/tls"
+	"golang.org/x/crypto/acme"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -11,7 +13,7 @@ import (
 func main() {
 	e := echo.New()
 	// e.AutoTLSManager.HostPolicy = autocert.HostWhitelist("<DOMAIN>")
-	// Cache certificates
+	// Cache certificates to avoid issues with rate limits (https://letsencrypt.org/docs/rate-limits)
 	e.AutoTLSManager.Cache = autocert.DirCache("/var/www/.cache")
 	e.Use(middleware.Recover())
 	e.Use(middleware.Logger())
@@ -21,5 +23,38 @@ func main() {
 			<h3>TLS certificates automatically installed from Let's Encrypt :)</h3>
 		`)
 	})
+
 	e.Logger.Fatal(e.StartAutoTLS(":443"))
+}
+
+func customHTTPServer() {
+	e := echo.New()
+	e.Use(middleware.Recover())
+	e.Use(middleware.Logger())
+	e.GET("/", func(c echo.Context) error {
+		return c.HTML(http.StatusOK, `
+			<h1>Welcome to Echo!</h1>
+			<h3>TLS certificates automatically installed from Let's Encrypt :)</h3>
+		`)
+	})
+
+	autoTLSManager := autocert.Manager{
+		Prompt: autocert.AcceptTOS,
+		// Cache certificates to avoid issues with rate limits (https://letsencrypt.org/docs/rate-limits)
+		Cache: autocert.DirCache("/var/www/.cache"),
+		//HostPolicy: autocert.HostWhitelist("<DOMAIN>"),
+	}
+	s := http.Server{
+		Addr:    ":443",
+		Handler: e, // set Echo as handler
+		TLSConfig: &tls.Config{
+			//Certificates: nil, // <-- s.ListenAndServeTLS will populate this field
+			GetCertificate: autoTLSManager.GetCertificate,
+			NextProtos:     []string{acme.ALPNProto},
+		},
+		//ReadTimeout: 30 * time.Second, // use custom timeouts
+	}
+	if err := s.ListenAndServeTLS("", ""); err != http.ErrServerClosed {
+		e.Logger.Fatal(err)
+	}
 }

--- a/website/content/cookbook/embed-resources.md
+++ b/website/content/cookbook/embed-resources.md
@@ -6,14 +6,6 @@ description = "Embed resources recipe for Echo"
   parent = "cookbook"
 +++
 
-## With go.rice
-
-`server.go`
-
-{{< embed "embed-resources/server.go" >}}
-
-## [Source Code]({{< source "embed-resources" >}})
-
 ## With go 1.16 embed feature
 
 `server.go`
@@ -22,3 +14,10 @@ description = "Embed resources recipe for Echo"
 
 ## [Source Code]({{< source "embed" >}})
 
+## With go.rice
+
+`server.go`
+
+{{< embed "embed-resources/server.go" >}}
+
+## [Source Code]({{< source "embed-resources" >}})

--- a/website/content/cookbook/http2-server-push.md
+++ b/website/content/cookbook/http2-server-push.md
@@ -40,10 +40,26 @@ e.GET("/", func(c echo.Context) (err error) {
 
 If `http.Pusher` is supported, web assets are pushed; otherwise, client makes separate requests to get them.
 
-### Step 4: Configure TLS server using `cert.pem` and `key.pem`
+### Step 4: Start TLS server using `cert.pem` and `key.pem`
 
 ```go
-e.StartTLS(":1323", "cert.pem", "key.pem")
+if err := e.StartTLS(":1323", "cert.pem", "key.pem"); err != http.ErrServerClosed {
+  log.Fatal(err)
+}
+```
+or use customized HTTP server with your own TLSConfig
+```go
+s := http.Server{
+  Addr:    ":8443",
+  Handler: e, // set Echo as handler
+  TLSConfig: &tls.Config{
+    //Certificates: nil, // <-- s.ListenAndServeTLS will populate this field
+  },
+  //ReadTimeout: 30 * time.Second, // use custom timeouts
+}
+if err := s.ListenAndServeTLS("cert.pem", "key.pem"); err != http.ErrServerClosed {
+  log.Fatal(err)
+}
 ```
 
 ### Step 5: Start the server and browse to https://localhost:1323

--- a/website/content/cookbook/http2.md
+++ b/website/content/cookbook/http2.md
@@ -37,10 +37,26 @@ e.GET("/request", func(c echo.Context) error {
 })
 ```
 
-### Step 3: Configure TLS server using `cert.pem` and `key.pem`
+### Step 3: Start TLS server using `cert.pem` and `key.pem`
 
 ```go
-e.StartTLS(":1323", "cert.pem", "key.pem")
+if err := e.StartTLS(":1323", "cert.pem", "key.pem"); err != http.ErrServerClosed {
+  log.Fatal(err)
+}
+```
+or use customized HTTP server with your own TLSConfig
+```go
+s := http.Server{
+  Addr:    ":8443",
+  Handler: e, // set Echo as handler
+  TLSConfig: &tls.Config{
+    //Certificates: nil, // <-- s.ListenAndServeTLS will populate this field
+  },
+  //ReadTimeout: 30 * time.Second, // use custom timeouts
+}
+if err := s.ListenAndServeTLS("cert.pem", "key.pem"); err != http.ErrServerClosed {
+  log.Fatal(err)
+}
 ```
 
 ### Step 4: Start the server and browse to https://localhost:1323/request to see the following output

--- a/website/content/guide/customization.md
+++ b/website/content/guide/customization.md
@@ -73,38 +73,6 @@ Default value is `ERROR`. Possible values:
 Logging is implemented using `echo.Logger` interface which allows you to register
 a custom logger using `Echo#Logger`.
 
-## Custom Server
-
-`Echo#StartServer()` can be used to run a custom server.
-
-*Example*
-
-```go
-s := &http.Server{
-  Addr:         ":1323",
-  ReadTimeout:  20 * time.Minute,
-  WriteTimeout: 20 * time.Minute,
-}
-e.Logger.Fatal(e.StartServer(s))
-```
-
-## Custom HTTP/2 Cleartext Server
-
-`Echo#StartH2CServer()` can be used to run a custom HTTP/2 cleartext server.
-
-*Example*
-
-```go
-import "golang.org/x/net/http2"
-
-s := &http2.Server{
-  MaxConcurrentStreams: 250,
-  MaxReadFrameSize:     1048576,
-  IdleTimeout:          10 * time.Second,
-}
-e.Logger.Fatal(e.StartH2CServer(":1323", s))
-```
-
 ## Startup Banner
 
 `Echo#HideBanner` can be used to hide the startup banner.

--- a/website/content/guide/http_server.md
+++ b/website/content/guide/http_server.md
@@ -16,7 +16,7 @@ Echo provides following convenience methods to start HTTP server with Echo as a 
 
 ## HTTP Server
 
-`Echo.Start` is convenience method that starts http server with Echo serving requests on port 8080.
+`Echo.Start` is convenience method that starts http server with Echo serving requests.
 ```go
 func main() {
   e := echo.New()
@@ -28,7 +28,7 @@ func main() {
 }
 ```
 
-Following is equivalent to `Echo.Start`
+Following is equivalent to `Echo.Start` previous example
 ```go
 func main() {
   e := echo.New()
@@ -47,7 +47,7 @@ func main() {
 
 ## HTTPS Server
 
-`Echo.StartTLS` is convenience method that starts HTTPS server with Echo serving requests on port 8443 and uses 
+`Echo.StartTLS` is convenience method that starts HTTPS server with Echo serving requests on given address and uses 
 `server.crt` and `server.key` as TLS certificate pair.
 ```go
 func main() {
@@ -60,7 +60,7 @@ func main() {
 }
 ```
 
-Following is equivalent to `Echo.StartTLS`
+Following is equivalent to `Echo.StartTLS` previous example
 ```go
 func main() {
   e := echo.New()
@@ -86,7 +86,7 @@ See [Auto TLS Recipe](/cooobook/auto-tls#server)
 
 ## HTTP/2 Cleartext Server (HTTP2 over HTTP)
 
-`Echo.StartH2CServer` is convenience method that starts a custom HTTP/2 cleartext server on port 8080
+`Echo.StartH2CServer` is convenience method that starts a custom HTTP/2 cleartext server on given address
 ```go
 func main() {
   e := echo.New()
@@ -103,7 +103,7 @@ func main() {
 }
 ```
 
-Following is equivalent to `Echo.StartH2CServer`
+Following is equivalent to `Echo.StartH2CServer` previous example
 ```go
 func main() {
   e := echo.New()

--- a/website/content/guide/http_server.md
+++ b/website/content/guide/http_server.md
@@ -1,0 +1,125 @@
++++
+title = "Starting HTTP(S) server with Echo"
+description = "Serving Echo from HTTP(S) server"
+[menu.main]
+name = "HTTP(s) Server"
+parent = "guide"
++++
+
+Echo provides following convenience methods to start HTTP server with Echo as a request handler:
+
+* `Echo.Start(address string)`
+* `Echo.StartTLS(address string, certFile, keyFile interface{})`
+* `Echo.StartAutoTLS(address string)`
+* `Echo.StartH2CServer(address string, h2s *http2.Server)`
+* `Echo.StartServer(s *http.Server)`
+
+## HTTP Server
+
+`Echo.Start` is convenience method that starts http server with Echo serving requests on port 8080.
+```go
+func main() {
+  e := echo.New()
+  // add middleware and routes
+  // ...
+  if err := e.Start(":8080"); err != http.ErrServerClosed {
+    log.Fatal(err)
+  }
+}
+```
+
+Following is equivalent to `Echo.Start`
+```go
+func main() {
+  e := echo.New()
+  // add middleware and routes
+  // ...
+  s := http.Server{
+    Addr:        ":8080",
+    Handler:     e,
+    //ReadTimeout: 30 * time.Second, // customize http.Server timeouts
+  }
+  if err := s.ListenAndServe(); err != http.ErrServerClosed {
+    log.Fatal(err)
+  }
+}
+```
+
+## HTTPS Server
+
+`Echo.StartTLS` is convenience method that starts HTTPS server with Echo serving requests on port 8443 and uses 
+`server.crt` and `server.key` as TLS certificate pair.
+```go
+func main() {
+  e := echo.New()
+  // add middleware and routes
+  // ...
+  if err := e.StartTLS(":8443", "server.crt", "server.key"); err != http.ErrServerClosed {
+    log.Fatal(err)
+  }
+}
+```
+
+Following is equivalent to `Echo.StartTLS`
+```go
+func main() {
+  e := echo.New()
+  // add middleware and routes
+  // ...
+  s := http.Server{
+    Addr:    ":8443",
+    Handler: e, // set Echo as handler
+    TLSConfig: &tls.Config{
+      //MinVersion: 1, // customize TLS configuration
+    },
+    //ReadTimeout: 30 * time.Second, // use custom timeouts
+  }
+  if err := s.ListenAndServeTLS("server.crt", "server.key"); err != http.ErrServerClosed {
+    log.Fatal(err)
+  }
+}
+```
+
+## Auto TLS Server with Let’s Encrypt
+
+See [Auto TLS Recipe](/cooobook/auto-tls#server)
+
+## HTTP/2 Cleartext Server (HTTP2 over HTTP)
+
+`Echo.StartH2CServer` is convenience method that starts a custom HTTP/2 cleartext server on port 8080
+```go
+func main() {
+  e := echo.New()
+  // add middleware and routes
+  // ...
+  s := &http2.Server{
+    MaxConcurrentStreams: 250,
+    MaxReadFrameSize:     1048576,
+    IdleTimeout:          10 * time.Second,
+  }
+  if err := e.StartH2CServer(":8080", s); err != http.ErrServerClosed {
+    log.Fatal(err)
+  }
+}
+```
+
+Following is equivalent to `Echo.StartH2CServer`
+```go
+func main() {
+  e := echo.New()
+  // add middleware and routes
+  // ...
+  h2s := &http2.Server{
+    MaxConcurrentStreams: 250,
+    MaxReadFrameSize:     1048576,
+    IdleTimeout:          10 * time.Second,
+  }
+  s := http.Server{
+    Addr:    ":8080",
+    Handler: h2c.NewHandler(e, h2s),
+  }
+  if err := s.ListenAndServe(); err != http.ErrServerClosed {
+    log.Fatal(err)
+  }
+}
+```

--- a/website/content/guide/installation.md
+++ b/website/content/guide/installation.md
@@ -10,34 +10,33 @@ weight = 1
 ## Prerequisites
 
 - [Install](https://golang.org/doc/install) Go
-- [Set](https://golang.org/doc/code.html#GOPATH) GOPATH
 
 ## Using [go get](https://golang.org/cmd/go/#hdr-Download_and_install_packages_and_dependencies)
 
 ```sh
 $ cd <PROJECT IN $GOPATH>
-$ go get -u github.com/labstack/echo/...
+$ go get -u github.com/labstack/echo/v4
 ```
 
 ## Using [dep](https://github.com/golang/dep)
 
 ```sh
 $ cd <PROJECT IN $GOPATH>
-$ dep ensure -add github.com/labstack/echo@^3.1
+$ dep ensure -add github.com/labstack/echo@^4.3
 ```
 
 ## Using [glide](http://glide.sh)
 
 ```sh
 $ cd <PROJECT IN $GOPATH>
-$ glide get github.com/labstack/echo#~3.1
+$ glide get github.com/labstack/echo#~4.3
 ```
 
 ## Using [govendor](https://github.com/kardianos/govendor)
 
 ```sh
 $ cd <PROJECT IN $GOPATH>
-$ govendor fetch github.com/labstack/echo@v3.1
+$ govendor fetch github.com/labstack/echo@v4.3
 ```
 
 Echo follows [semantic versioning](http://semver.org) managed through GitHub

--- a/website/layouts/_default/single.html
+++ b/website/layouts/_default/single.html
@@ -12,6 +12,16 @@
             <section>
               {{ $url := replace .Permalink (printf "%s" .Site.BaseURL) "" }}
               {{ $.Scratch.Add "path" (printf "%s" .Site.BaseURL) }}
+                <style>
+                    .hanchor {
+                        font-size: 80%;
+                        visibility: hidden;
+                        color: silver;
+                    }
+                    h1:hover a, h2:hover a, h3:hover a, h4:hover a {
+                        visibility: visible;
+                    }
+                </style>
               <ul class="breadcrumb">
                 <!-- <li><a href="/">home</a></li> -->
                 {{ range $index, $element := split $url "/" }}
@@ -23,7 +33,7 @@
                 {{ end }}
               </ul>
               <h1>{{ .Title }}</h1>
-              {{ .Content }}
+                {{ .Content | replaceRE  "(<h[1-9] id=\"([^\"]+)\".+)(</h[1-9]+>)" `${1}<a href="#${2}" class="hanchor" ariaLabel="Anchor"> 🔗</a> ${3}` | safeHTML }}
             </section>
             <footer>
               Caught a mistake?


### PR DESCRIPTION
Add page describing how to start (custom) HTTP(s) server with Echo
Add anchor behind h1/h2/h2 elements to make linking easier

This is to address questions related to starting Echo with custom (TLS or http.Server) settings. 
Also should be helpful for cases it feels that we need new introduce fields because current API is too limiting ala https://github.com/labstack/echo/pull/1894
