### PR TITLE
Update ad link as it goes to a 404

### DIFF
--- a/website/layouts/partials/ad.html
+++ b/website/layouts/partials/ad.html
@@ -1,5 +1,5 @@
 <div class="w3-container ad">
-  <a href="https://code.labstack.com/new">
+  <a href="https://code.labstack.com/">
     <img
       style="margin-bottom: 8px;"
       src="{{.Site.BaseURL}}/images/code.png"


### PR DESCRIPTION
`https://code.labstack.com/new` no longer exists, it's a 404. Presume you want this ad to point to the root so ppl can get started :-)