### PR TITLE
Fix testing example in docs

### DIFF
--- a/website/content/guide/testing.md
+++ b/website/content/guide/testing.md
@@ -86,7 +86,8 @@ var (
 	mockDB = map[string]*User{
 		"jon@labstack.com": &User{"Jon Snow", "jon@labstack.com"},
 	}
-	userJSON = `{"name":"Jon Snow","email":"jon@labstack.com"}`
+	userJSON = `{"name":"Jon Snow","email":"jon@labstack.com"}
+`
 )
 
 func TestCreateUser(t *testing.T) {


### PR DESCRIPTION
Fix the issue discussed in https://github.com/labstack/echox/issues/140

We need to add a new line for the expected JSON to pass the test.
```sh
$ go test -run ^TestCreateUser$                     
PASS
ok      echo-testing/handler    0.108s
```