### PR TITLE
Revert "Fix template name in template.md"

### DIFF
--- a/website/content/guide/templates.md
+++ b/website/content/guide/templates.md
@@ -51,7 +51,7 @@ Example below shows how to use Go `html/template`:
 
     ```go
     func Hello(c echo.Context) error {
-    	return c.Render(http.StatusOK, "hello", "World")
+    	return c.Render(http.StatusOK, "hello.html", "World")
     }
     ```
 


### PR DESCRIPTION
per https://pkg.go.dev/html/template#ParseGlob the template name is
"the (base) name and (parsed) contents of the first file matched by the
pattern", so `hello.html` was correct.

This reverts commit cc451ec9493ad022972680151b2de137d98627ae.