### PR TITLE
Replace curl's -F option with the -d option

### DIFF
--- a/website/content/guide.md
+++ b/website/content/guide.md
@@ -121,7 +121,7 @@ func save(c echo.Context) error {
 Run the following command:
 
 ```sh
-$ curl -F "name=Joe Smith" -F "email=joe@labstack.com" http://localhost:1323/save
+$ curl -d "name=Joe Smith" -d "email=joe@labstack.com" http://localhost:1323/save
 // => name:Joe Smith, email:joe@labstack.com
 ```
 


### PR DESCRIPTION
Hi!

curl's -F option sends data with `multipart/form-data` header,
but the option is used as an example in the `application/x-www-form-urlencoded` section.
The correct option is curl's -d (--data) option.