### PR TITLE
Document path paramater behaviour for same path across different methods

### DIFF
--- a/website/content/guide/request.md
+++ b/website/content/guide/request.md
@@ -71,6 +71,10 @@ e.GET("/users/:name", func(c echo.Context) error {
 curl http://localhost:1323/users/Joe
 ```
 
+Note that when registering the same path for multiple methods, the path parameter
+name needs to be the same.  All paths will be registered using the name from the
+first path.
+
 ### Binding Data
 
 Also binding of request data to native Go structs and variables is supported.


### PR DESCRIPTION
While registering a path across multiple methods I discovered all must use the same path paramater name.  I only found mention of this unexpected behaviour in GitHub issues (see [here ](https://github.com/labstack/echo/issues/479)and [here ](https://github.com/labstack/echo/issues/1744)for e.g.) and figured it's worth calling out in the docs.