### PR TITLE
docs: Add custom prometheus metrics guide

### DIFF
--- a/website/content/middleware/prometheus.md
+++ b/website/content/middleware/prometheus.md
@@ -51,6 +51,100 @@ echo_response_size_bytes_count 1
 
 ## Custom Configuration
 
+### Serving custom Prometheus Metrics
+*Usage*
+
+When creating a new Prometheus middleware, you can pass down a list of extra []*Metric array you can use.
+
+```go
+package main
+
+import (
+	"time"
+
+	"github.com/labstack/echo-contrib/prometheus"
+	"github.com/labstack/echo/v4"
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+const cKeyMetrics = "custom_metrics"
+
+// See the NewMetrics func for proper descriptions and prometheus names!
+// In case you add a metric here later, make sure to include it in the
+// MetricsList method or you'll going to have a bad time.
+type Metrics struct {
+	customCnt *prometheus.Metric
+	customDur *prometheus.Metric
+}
+
+// Needed by echo-contrib so echo can register and collect these metrics
+func (m *Metrics) MetricList() []*prometheus.Metric {
+	return []*prometheus.Metric{
+		// ADD EVERY METRIC HERE!
+		m.customCnt,
+		m.customDur,
+	}
+}
+
+// Creates and populates a new Metrics struct
+// This is where all the prometheus metrics, names and labels are specified
+func NewMetrics() *Metrics {
+	return &Metrics{
+		customCnt: &prometheus.Metric{
+			Name:        "custom_total",
+			Description: "Custom counter events.",
+			Type:        "counter_vec",
+			Args:        []string{"label_one", "label_two"},
+		},
+		customDur: &prometheus.Metric{
+			Name:        "custom_duration_seconds",
+			Description: "Custom duration observations.",
+			Type:        "histogram_vec",
+			Args:        []string{"label_one", "label_two"},
+			Buckets:     prom.DefBuckets, // or your Buckets
+		},
+	}
+}
+
+// This will push your metrics object into every request context for later use
+func (m *Metrics) AddCustomMetricsMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Set(cKeyMetrics, m)
+		return next(c)
+	}
+}
+
+func (m *Metrics) IncCustomCnt(labelOne, labelTwo string) {
+	labels := prom.Labels{"label_one": labelOne, "label_two": labelTwo}
+	m.customCnt.MetricCollector.(*prom.CounterVec).With(labels).Inc()
+}
+
+func (m *Metrics) ObserveCustomDur(labelOne, labelTwo string, d time.Duration) {
+	labels := prom.Labels{"label_one": labelOne, "label_two": labelTwo}
+	m.customCnt.MetricCollector.(*prom.HistogramVec).With(labels).Observe(d.Seconds())
+}
+
+func main() {
+	e := echo.New()
+	m := NewMetrics()
+
+	// Enable metrics middleware
+	p := prometheus.NewPrometheus("echo", nil, m.MetricList())
+	p.Use(e)
+
+	e.Use(m.AddCustomMetricsMiddleware)
+
+	e.GET("/custom", func(c echo.Context) error {
+		metrics := c.Get(cKeyMetrics).(*Metrics)
+		metrics.IncCustomCnt("any", "value")
+		return nil
+	})
+
+	e.Logger.Fatal(e.Start(":1323"))
+}
+```
+
+### Skipping certain URLs
 *Usage*
 
 A middleware skipper can be passed to avoid generating metrics to certain URLs:


### PR DESCRIPTION
As the example shows, it's not straight-forward how to use the middleware for serving custom metrics (along with the default ones). I haven't found any guide initially for doing such work. There is also an [issue in the middleware's repository](https://github.com/labstack/echo-contrib/issues/76)  asking for guidance about this problem. 

It took me a while to figure everything out while digging around in the `labstack/echo-contrib` repo's code. With this addition to the documentation, I expect others will have an easier way to onboard this middleware to their apps.

