### PR TITLE
Update Set ID Code displaying online to a block

### DIFF
--- a/website/content/middleware/request-id.md
+++ b/website/content/middleware/request-id.md
@@ -55,11 +55,11 @@ DefaultRequestIDConfig = RequestIDConfig{
 You can set the id from the requester with the `X-Request-ID`-Header
 
 *request*
-```
+`
 curl -H "X-Request-ID: 3" --compressed -v "http://localhost:1323/?my=param"
-```
+`
 
 *Log*
-```
+`
 {"time":"2017-11-13T20:26:28.6438003+01:00","id":"3","remote_ip":"::1","host":"localhost:1323","method":"GET","uri":"/?my=param","my":"param","status":200, "latency":0,"latency_human":"0s","bytes_in":0,"bytes_out":13}
-```
+`


### PR DESCRIPTION
Output codes in `request` and `Log` are displaying in online on the website. The log code is cut in half and did not display properly. By removing thises (```), it displays in the block, and all the `Log` codes are visible on the website.