### PR TITLE
Update CSRF doc with cookie option and example

### DIFF
--- a/website/content/middleware/csrf.md
+++ b/website/content/middleware/csrf.md
@@ -57,6 +57,7 @@ CSRFConfig struct {
   // - "header:<name>"
   // - "form:<name>"
   // - "query:<name>"
+  // - "cookie:<name>"
   TokenLookup string `json:"token_lookup"`
 
   // Context key to store generated CSRF token into context.
@@ -101,3 +102,16 @@ DefaultCSRFConfig = CSRFConfig{
   CookieMaxAge: 86400,
 }
 ```
+
+
+*Example Configuration that reads token from Cookie*
+
+```go
+middleware.CSRFWithConfig(middleware.CSRFConfig{
+	TokenLookup:    "cookie:_csrf",
+	CookiePath:     "/",
+	CookieDomain:   "example.com",
+	CookieSecure:   true,
+	CookieHTTPOnly: true,
+	CookieSameSite: http.SameSiteStrictMode,
+})


### PR DESCRIPTION
PR:
- adds hidden option that allows to read token value from cookie
- adds copy-and-paste example of how to use it

