### PR TITLE
Fixed example using ioutil

### DIFF
--- a/website/content/guide/customization.md
+++ b/website/content/guide/customization.md
@@ -55,7 +55,7 @@ if l, ok := e.Logger.(*log.Logger); ok {
 `Echo#Logger.SetOutput(io.Writer)` can be used to set the output destination for
 the logger. Default value is `os.Stdout`
 
-To completely disable logs use `Echo#Logger.SetOutput(ioutil.Discard)` or `Echo#Logger.SetLevel(log.OFF)`
+To completely disable logs use `Echo#Logger.SetOutput(io.Discard)` or `Echo#Logger.SetLevel(log.OFF)`
 
 ### Log Level
 

--- a/website/content/guide/routing.md
+++ b/website/content/guide/routing.md
@@ -173,7 +173,7 @@ data, err := json.MarshalIndent(e.Routes(), "", "  ")
 if err != nil {
 	return err
 }
-ioutil.WriteFile("routes.json", data, 0644)
+os.WriteFile("routes.json", data, 0644)
 ```
 
 `routes.json`


### PR DESCRIPTION
`ioutil` is deprecated from Go1.16. But in docs, still use `ioutil`, so I replaced that function or variable with suggested in godoc.

references:
https://pkg.go.dev/io/ioutil#pkg-variables
https://pkg.go.dev/io/ioutil#WriteFile