### PR TITLE
Add "A Note on Concurrency"

### DIFF
--- a/website/content/guide/context.md
+++ b/website/content/guide/context.md
@@ -57,32 +57,18 @@ e.GET("/", func(c echo.Context) error {
 
 ## A Note on Concurrency
 
-`Context` should not be accessed concurrently. It has functions that are dangerous to execute from multiple goroutines. For example have a look at [Request](https://github.com/labstack/echo/blob/0ce73028d0815e0ecec80964cc2da42d98fafa33/context.go#L231) and [SetRequest](https://github.com/labstack/echo/blob/0ce73028d0815e0ecec80964cc2da42d98fafa33/context.go#L235).
+`Context` must not be accessed out of the goroutine handling the request. There are two reasons:
 
-If you would like to see for yourself, add the route below to your code and compile with race detector enabled: `go build -race`. Then send an HTTP request to it, and see what happens.
+1. `Context` has functions that are dangerous to execute from multiple goroutines. Therefore, only one goroutine should access it.
+2. Echo uses a pool to create `Context`'s. When the request handling finishes, Echo returns the `Context` to the pool.
 
-```go
-func(c echo.Context) error {
-	go func() {
-		for i := 0; i < 100; i++ {
-			r := c.Request()
-			r, _ = http.NewRequest("GET", "/", nil)
-			c.SetRequest(r)
-		}
-	}()
-
-	for i := 0; i < 100; i++ {
-		r := c.Request()
-		r, _ = http.NewRequest("GET", "/", nil)
-		c.SetRequest(r)
-	}
-	return nil
-}
-```
+See issue [1908](https://github.com/labstack/echo/issues/1908) for a "cautionary tale" caused by this reason.
 
 ### Solutions
 
 #### Use a channel
+
+A better design is to use a channel:
 
 ```go
 func(c echo.Context) error {


### PR DESCRIPTION
`Context` is not concurrent-safe. Although it is a rare condition to access the `Context` concurrently, I pedantically thought it should be documented.