### PR TITLE
Fix err declaration on echo binding example

### DIFF
--- a/website/docs/guide/binding.md
+++ b/website/docs/guide/binding.md
@@ -126,7 +126,7 @@ And a handler at the POST `/users` route binds request data to the struct:
 ```go
 e.POST("/users", func(c echo.Context) (err error) {
   u := new(User)
-  if err = c.Bind(u); err != nil {
+  if err := c.Bind(u); err != nil {
     return c.String(http.StatusBadRequest, "bad request")
   }
 


### PR DESCRIPTION
Changes the syntax from `err = c.Bind(u)` to `err := c.Bind(c)`, the former does not compile because `err` was not defined yet.