### PR TITLE
Update binding.md

### DIFF
--- a/website/docs/guide/binding.md
+++ b/website/docs/guide/binding.md
@@ -193,7 +193,7 @@ length := int64(50) // default length is 50
 // creates query params binder that stops binding at first error
 err := echo.QueryParamsBinder(c).
   Int64("length", &length).
-  Int64s("ids", &opts.IDs).
+  Int64s("id", &opts.IDs).
   Bool("active", &opts.Active).
   BindError() // returns first binding error
 ```


### PR DESCRIPTION
Change `ids` to `id` to be consistent with the example API route, which uses `id`. The response returns `null IDs` when using the current example, which is expected to work on the go.