### PR TITLE
Fix broken link to `binding.md` guide in `Request` guide

### DIFF
--- a/website/docs/guide/request.md
+++ b/website/docs/guide/request.md
@@ -74,7 +74,7 @@ curl http://localhost:1323/users/Joe
 ### Binding Data
 
 Also binding of request data to native Go structs and variables is supported.
-See [Binding Data]({{< ref "guide/binding.md">}})
+See [Binding Data](./binding.md)
 
 ## Validate Data
 


### PR DESCRIPTION
# Before

As of 14 September 2023, the link to `binding.md` guide is broken, see (https://echo.labstack.com/docs/request#binding-data)

<img width="1423" alt="Screenshot 2023-09-14 at 1 13 50 AM" src="https://github.com/labstack/echox/assets/65026286/09e121ad-c470-43a9-95f6-2d71b80b4085">

# Proposed Changes

After the change, it looks like this:

<img width="1428" alt="Screenshot 2023-09-14 at 1 15 32 AM" src="https://github.com/labstack/echox/assets/65026286/0d2ee780-0b53-4510-af3e-c990e078e877">

It links to the binding page:

<img width="1428" alt="image" src="https://github.com/labstack/echox/assets/65026286/92cfc864-6385-4472-81d9-7163fac3eaab">

