### PR TITLE
doc: update timeout.md

### DIFF
--- a/website/docs/middleware/timeout.md
+++ b/website/docs/middleware/timeout.md
@@ -19,45 +19,50 @@ e.Use(middleware.Timeout())
 ```go
 e := echo.New()
 e.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
-  Skipper: Skipper,
-  ErrorHandler: func(err error, e echo.Context) error {
-      // you can handle your error here, the returning error will be 
-      // passed down the middleware chain
-      return err
+  Skipper:                     middleware.DefaultSkipper,
+  ErrorMessage:                "custom timeout error message returns to client",
+  OnTimeoutRouteErrorHandler:  func(err error, c echo.Context) {
+    log.Println(c.Path())
   },
-  Timeout: 30*time.Second,
+  Timeout:                     30*time.Second,
 }))
 ```
+`OnTimeoutRouteErrorHandler` is an error handler that is executed for error that was returned from wrapped route after request timeouted and we already had sent the error code (503) and message response to the client.
+```go
+OnTimeoutRouteErrorHandler func(err error, c echo.Context)
+```
+Note: do not write headers/body inside this handler. The response has already been sent to the client and response writer
+will not accept anything no more. handler in the previous example will log the actual route middleware timeouted.
 
 ## Configuration
 
 ```go
 // TimeoutConfig defines the config for Timeout middleware.
 TimeoutConfig struct {
-    // Skipper defines a function to skip middleware.
-    Skipper Skipper
-    // ErrorHandler defines a function which is executed for a timeout
-    // It can be used to define a custom timeout error
-    ErrorHandler TimeoutErrorHandlerWithContext
-    // Timeout configures a timeout for the middleware, defaults to 0 for no timeout
-    Timeout time.Duration
+  // Skipper defines a function to skip middleware.
+  Skipper Skipper
+
+  // ErrorMessage is written to response on timeout in addition to http.StatusServiceUnavailable (503) status code
+  ErrorMessage string
+
+  // OnTimeoutRouteErrorHandler is an error handler that is executed for error that was returned from wrapped route after
+  // request timeouted and we already had sent the error code (503) and message response to the client.
+  OnTimeoutRouteErrorHandler func(err error, c echo.Context)
+
+  // Timeout configures a timeout for the middleware, defaults to 0 for no timeout
+  Timeout time.Duration
 }
 ```
 
-`TimeoutErrorHandlerWithContext` is responsible for handling the errors when a timeout happens
-```go
-// TimeoutErrorHandlerWithContext is an error handler that is used 
-// with the timeout middleware so we can handle the error 
-// as we see fit
-TimeoutErrorHandlerWithContext func(error, echo.Context) error
-```
 
 ### Default Configuration*
 
 ```go
+// DefaultTimeoutConfig is the default Timeout middleware config.
 DefaultTimeoutConfig = TimeoutConfig{
-    Skipper:      DefaultSkipper,
-    Timeout:      0,
-    ErrorHandler: nil,
+  Skipper:      DefaultSkipper,
+  Timeout:      0,
+  ErrorMessage: "",
+  // Note that OnTimeoutRouteErrorHandler will be nil
 }
 ```


### PR DESCRIPTION
timeout middleware has changed and previous guide not work anymore.
`ErrorHandler` field has removed from `TimeoutConfig` and two other fields `ErrorMessage` and `OnTimeoutRouteErrorHandler` added to it.
this commit updated timeout.md