### PR TITLE
fix: typos in documentation

### DIFF
--- a/website/docs/cookbook/google-app-engine.md
+++ b/website/docs/cookbook/google-app-engine.md
@@ -33,7 +33,7 @@ https://github.com/labstack/echox/blob/master/cookbook/google-app-engine/app.go
 
 A separate source file contains the function to create the Echo instance and add the static
 file handlers and middleware. Note the build tag on the first line which says to use this when _not_
-bulding with appengine or appenginevm tags (which thoese platforms automatically add for us). We also
+building with appengine or appenginevm tags (which those platforms automatically add for us). We also
 have the `main()` function to start serving our app as normal. This should all be very familiar.
 
 ```go reference

--- a/website/docs/guide/ip-address.md
+++ b/website/docs/guide/ip-address.md
@@ -43,7 +43,7 @@ e.IPExtractor = echo.ExtractIPDirect()
 
 ## Case 2. With proxies using X-Forwarded-For header
 
-[`X-Forwared-For` (XFF)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) is the popular header to relay clients' IP addresses.
+[`X-Forwarded-For` (XFF)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) is the popular header to relay clients' IP addresses.
 At each hop on the proxies, they append the request IP address at the end of the header.
 
 Following example diagram illustrates this behavior.

--- a/website/docs/guide/routing.md
+++ b/website/docs/guide/routing.md
@@ -43,7 +43,7 @@ match:
 :::caution
 
 There can be only one effective match-any parameter in route. When route is added with multiple match-any
-`/v1/*/images/*`. The router matches always the first `*` till the end of requst URL i.e. it works as `/v1/*`.
+`/v1/*/images/*`. The router matches always the first `*` till the end of request URL i.e. it works as `/v1/*`.
 
 :::
 

--- a/website/docs/middleware/jaeger.md
+++ b/website/docs/middleware/jaeger.md
@@ -43,7 +43,7 @@ $ JAEGER_AGENT_HOST=192.168.1.10 JAEGER_AGENT_PORT=6831 ./myserver
 ```
 
 The tracer can be initialized with values coming from environment variables. None of the env vars are required
-and all of them can be overriden via direct setting of the property on the configuration object.
+and all of them can be overridden via direct setting of the property on the configuration object.
 
 Property| Description
 --- | ---

--- a/website/docs/middleware/static.md
+++ b/website/docs/middleware/static.md
@@ -49,7 +49,7 @@ To turn off this behavior set the `IgnoreBase` config param to `true`.
 
 #### Example 2
 
-Serve SPA assets from embbeded filesystem
+Serve SPA assets from embedded filesystem
 ```go
 //go:embed web
 var webAssets embed.FS


### PR DESCRIPTION
## Description
Correct the typos in the documentation: 
- change `bulding` to `building` 
- change `thoese` to `those`
- change `Forwared` to `Forwarded`
- change `requst` to `request`
- change `overriden` to `overridden`
- change `embbeded` to `embedded`