### PR TITLE
response: clarify Content-Disposition, close file in Stream example

### DIFF
--- a/website/docs/guide/response.md
+++ b/website/docs/guide/response.md
@@ -244,7 +244,7 @@ func(c echo.Context) error {
 ## Send Attachment
 
 `Context#Attachment(file, name string)` is similar to `File()` except that it is
-used to send file as attachment with provided name.
+used to send file as `Content-Disposition: attachment` with provided name.
 
 *Example*
 
@@ -257,7 +257,7 @@ func(c echo.Context) error {
 ## Send Inline
 
 `Context#Inline(file, name string)` is similar to `File()` except that it is
-used to send file as inline with provided name.
+used to send file as `Content-Disposition: inline` with provided name.
 
 *Example*
 
@@ -296,6 +296,7 @@ func(c echo.Context) error {
   if err != nil {
     return err
   }
+  defer f.Close()
   return c.Stream(http.StatusOK, "image/png", f)
 }
 ```


### PR DESCRIPTION
Hello,

I just discovered Echo while reading Stripe's payments [Go demo](https://github.com/stripe-archive/stripe-payments-demo/tree/master/server/go), I'm going through the docs and so far I'm a big fan of the minimalistic approach! I hate bloat and love minimalist things (e.g. also just found [PicoCSS](https://picocss.com/) for web design). Good stuff, can't wait to start coding with it, and thank you for sharing it.

Anyhow, this PR proposes 2 minor changes:

1. When reading the [Response](https://echo.labstack.com/docs/response) doc, it wasn't clear to me what were the differences between [`Context#File`](https://echo.labstack.com/docs/response#send-file), [`Context#Attachment`](https://echo.labstack.com/docs/response#send-attachment) and [`Context#Inline`](https://echo.labstack.com/docs/response#send-inline). Reading the source made it clearer: the former 2 are referring to sending `Content-Disposition` with `attachment` and `inline`, which makes total sense. Therefore, I propose adding `Content-Disposition` to make this unambiguous.

2. Adding missing `defer f.Close()` in the `Context#Stream` example. I also checked, it takes an `io.Reader` not an `io.ReadCloser` so it couldn't delegate the close to `Context#Stream`, which could have worked otherwise!