### PR TITLE
response: fix example for Context#Inline

### DIFF
--- a/website/docs/guide/response.md
+++ b/website/docs/guide/response.md
@@ -263,7 +263,7 @@ used to send file as `Content-Disposition: inline` with provided name.
 
 ```go
 func(c echo.Context) error {
-  return c.Inline("<PATH_TO_YOUR_FILE>")
+  return c.Inline("<PATH_TO_YOUR_FILE>", "<FILE_NAME>")
 }
 ```
 


### PR DESCRIPTION
`Context#Inline` takes two args: `file` and `name`, but in the example code, only the first argument was given. Added second argument.