### PR TITLE
Add c.Response().Committed check in example customHTTPErrorHandler

### DIFF
--- a/website/docs/guide/error-handling.md
+++ b/website/docs/guide/error-handling.md
@@ -66,6 +66,10 @@ https://github.com/AndiDittrich/HttpErrorPages for pre-built error pages.
 
 ```go
 func customHTTPErrorHandler(err error, c echo.Context) {
+ 	if c.Response().Committed { 
+ 		return 
+ 	}
+
 	code := http.StatusInternalServerError
 	if he, ok := err.(*echo.HTTPError); ok {
 		code = he.Code


### PR DESCRIPTION
This doc updated addresses https://github.com/labstack/echo/issues/1948 in the best way I can guess it should be handled. @markhildreth-gravity [summarized](https://github.com/labstack/echo/issues/1948#issuecomment-1532179724) that issue best by offering three solutions:

> 1.) It's echo's responsibility to put this complexity into `c.Error()`, so that no third party needs to worry about this.
2.) It's the error handler's responsibility, in which case the documentation should be updated, or,
3.) It's the middleware's responsibility, in which case that documentation should be updated.

The first seems inappropriate since most handlers won't use `c.Error` (Its doc says this: "Avoid using this method in handlers as no middleware will be able to effectively handle errors after that.") The third puts more burden on developers since middleware functions are more common than error handlers.