### PR TITLE
docs: add testing middleware and handler section

### DIFF
--- a/website/docs/guide/testing.md
+++ b/website/docs/guide/testing.md
@@ -156,3 +156,19 @@ req := httptest.NewRequest(http.MethodGet, "/?"+q.Encode(), nil)
 *TBD*
 
 For now you can look into built-in middleware [test cases](https://github.com/labstack/echo/tree/master/middleware).
+
+## Testing Middleware and Handler
+
+```go
+e := echo.New()
+// ... register your middleware and handlers as normal
+
+req := httptest.NewRequest(http.MethodGet, "/api/apps", nil)
+req.Header.Set("Authorization", "Bearer " + yourToken) // e.g. if you use JWT middleware
+rec := httptest.NewRecorder()
+e.ServeHTTP(rec, req)
+
+// Assertions
+
+assert.Equal(t, http.StatusOK, rec.Code)
+```


### PR DESCRIPTION
Added a section on testing middleware and handlers with example code - this is useful for testing the entire request flow.