### PR TITLE
chore(docs): harden CI supply chain + update deps (#378)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # Astro docs site (site/). Group everything into a single weekly PR so the
+  # advisory stream is one reviewed change, not nonstop noise. No auto-merge —
+  # updates are deliberate (see the supply-chain hardening discussion in #378).
+  - package-ecosystem: npm
+    directory: /site
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      site-dependencies:
+        patterns:
+          - "*"
+
+  # Keep the GitHub Actions used by the deploy workflow current.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,6 +15,10 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
+    # Least privilege: the build only needs to push the gh-pages branch. Limits
+    # blast radius if a build-time dependency is ever compromised.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
@@ -23,8 +27,11 @@ jobs:
           cache: npm
           cache-dependency-path: site/package-lock.json
 
+      # --ignore-scripts blocks install/postinstall (and binding.gyp/node-gyp)
+      # supply-chain vectors — see npm worm advisories (Shai-Hulud). The build
+      # works without lifecycle scripts (sharp ships prebuilt binaries).
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: site
       - name: Build website
         run: npm run build

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,9 +8,9 @@
       "name": "echo-docs",
       "version": "0.1.0",
       "dependencies": {
-        "@astrojs/starlight": "0.40.0",
-        "astro": "6.4.6",
-        "sharp": "0.35.1"
+        "@astrojs/starlight": "^0.40.0",
+        "astro": "^6.4.7",
+        "sharp": "^0.35.1"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -2116,9 +2116,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.6.tgz",
-      "integrity": "sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.7.tgz",
+      "integrity": "sha512-5vsXx0H52u23Jpshs9tM81D03Tb3Oh2Vt2Zo0bpqjXN+njkAWjFyGjTfmWJLAcrCQd9Q+iWB1eqfhR1sZJEaUA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",

--- a/site/package.json
+++ b/site/package.json
@@ -9,8 +9,8 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "0.40.0",
-    "astro": "6.4.6",
-    "sharp": "0.35.1"
+    "@astrojs/starlight": "^0.40.0",
+    "astro": "^6.4.7",
+    "sharp": "^0.35.1"
   }
 }


### PR DESCRIPTION
Addresses the npm supply-chain concern from #378 while keeping the new Astro/Starlight docs site.

## Rationale
The docs site is **fully static** — no Node runs at runtime, so the only attack surface is the CI build. This PR hardens that surface rather than re-migrating to Hugo (which would mean rebuilding the Terminal theme; search/i18n/redirects were achievable but not worth the second migration).

## Changes
- **`npm ci --ignore-scripts`** in the deploy workflow — blocks install/postinstall and `binding.gyp`/node-gyp supply-chain vectors (Shai-Hulud class). Verified the build works without lifecycle scripts (`sharp` 0.35 ships prebuilt binaries).
- **Least-privilege token** — `permissions: { contents: write }` on the workflow, limiting blast radius if a build dep is compromised.
- **Dependabot** (`.github/dependabot.yml`) — grouped, weekly, reviewed (no auto-merge) for `site/` npm + github-actions. Turns the advisory stream into one deliberate PR (the "nonstop noise" in #378).
- **Deps → latest released** (astro 6.4.7; Starlight/sharp already latest). Pinned via committed lockfile with integrity hashes.

## Verified
Build green with `npm ci --ignore-scripts` (124 pages, 63 redirects), GA + CNAME intact.

Closes #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)