### PR TITLE
ci: deploy via official GitHub Pages Actions flow (least-privilege)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,14 +11,22 @@ on:
   # Allow manual runs from the Actions tab.
   workflow_dispatch:
 
+# Least privilege for the official GitHub Pages deployment: the token only needs
+# to publish Pages — no write access to repository source.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time; never cancel an in-progress one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  deploy:
-    name: Deploy to GitHub Pages
+  build:
+    name: Build
     runs-on: ubuntu-latest
-    # Least privilege: the build only needs to push the gh-pages branch. Limits
-    # blast radius if a build-time dependency is ever compromised.
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
@@ -33,25 +41,26 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
         working-directory: site
-      - name: Build website
+      - name: Build site
         run: npm run build
         working-directory: site
         env:
           # Lifts the GitHub API rate limit for build-time stats fetches.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Popular action to deploy to GitHub Pages:
-      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./site/dist
-          # The following lines assign commit authorship to the official
-          # GH-Actions bot for deploys to `gh-pages` branch:
-          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
-          # The GH actions bot is used by default if you didn't specify the two fields.
-          # You can swap them out with your own user credentials.
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+          path: site/dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Switches the deploy from `peaceiris/actions-gh-pages` (branch push, `contents: write`) to the official **`actions/upload-pages-artifact` + `actions/deploy-pages`** flow.

- Deploy token drops to **`contents: read`** (+ `pages: write`, `id-token: write`) — no write access to repo source.
- Keeps `npm ci --ignore-scripts`, the daily cron, and the build-time star fetch.
- Custom domain preserved via `site/public/CNAME` in the artifact.

**Activation (coordinated, brief downtime accepted):** after merge, the repo Pages **Source must be flipped to "GitHub Actions"** (`build_type=workflow`) and the workflow run completes the first Actions deployment. I'll do the flip + verify the live site (incl. custom domain) right after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)