### PR TITLE
docs: slice binding example (#170) + JWT timing-attack caveat (#100)

### DIFF
--- a/site/src/content/docs/cookbook/jwt.md
+++ b/site/src/content/docs/cookbook/jwt.md
@@ -47,7 +47,9 @@ func login(c *echo.Context) error {
 	username := c.FormValue("username")
 	password := c.FormValue("password")
 
-	// Throws unauthorized error
+	// Demo only: hard-coded credentials compared in plain text. In production,
+	// look up the user and verify a hashed password with a constant-time compare
+	// (e.g. golang.org/x/crypto/bcrypt's CompareHashAndPassword) to avoid timing attacks.
 	if username != "jon" || password != "shhh!" {
 		return echo.ErrUnauthorized
 	}

--- a/site/src/content/docs/es/cookbook/jwt.md
+++ b/site/src/content/docs/es/cookbook/jwt.md
@@ -47,7 +47,9 @@ func login(c *echo.Context) error {
 	username := c.FormValue("username")
 	password := c.FormValue("password")
 
-	// Throws unauthorized error
+	// Demo only: hard-coded credentials compared in plain text. In production,
+	// look up the user and verify a hashed password with a constant-time compare
+	// (e.g. golang.org/x/crypto/bcrypt's CompareHashAndPassword) to avoid timing attacks.
 	if username != "jon" || password != "shhh!" {
 		return echo.ErrUnauthorized
 	}

--- a/site/src/content/docs/es/guide/binding.md
+++ b/site/src/content/docs/es/guide/binding.md
@@ -44,6 +44,24 @@ if err := c.Bind(&user); err != nil {
 Los campos de path, query, header y form requieren un **tag explícito**. JSON y XML usan
 el nombre del campo del struct cuando se omite el tag, igual que la biblioteca estándar.
 
+### Slices
+
+Los valores repetidos de query, path, formulario o header se enlazan a un campo
+slice, que recoge cada aparición:
+
+```go
+// GET /search?tag=go&tag=web&tag=api
+type Filter struct {
+	Tags []string `query:"tag"`
+}
+
+var f Filter
+if err := c.Bind(&f); err != nil {
+	return c.String(http.StatusBadRequest, "bad request")
+}
+// f.Tags == []string{"go", "web", "api"}
+```
+
 ### Content types del body
 
 Al decodificar el body del request, el header `Content-Type` selecciona el decoder:

--- a/site/src/content/docs/guide/binding.md
+++ b/site/src/content/docs/guide/binding.md
@@ -44,6 +44,24 @@ if err := c.Bind(&user); err != nil {
 Path, query, header, and form fields require an **explicit tag**. JSON and XML fall
 back to the struct field name when the tag is omitted, matching the standard library.
 
+### Slices
+
+Repeated query, path, form, or header values bind to a slice field — the field
+collects every occurrence:
+
+```go
+// GET /search?tag=go&tag=web&tag=api
+type Filter struct {
+	Tags []string `query:"tag"`
+}
+
+var f Filter
+if err := c.Bind(&f); err != nil {
+	return c.String(http.StatusBadRequest, "bad request")
+}
+// f.Tags == []string{"go", "web", "api"}
+```
+
 ### Body content types
 
 When decoding the request body, the `Content-Type` header selects the decoder:

--- a/site/src/content/docs/ja/cookbook/jwt.md
+++ b/site/src/content/docs/ja/cookbook/jwt.md
@@ -46,7 +46,9 @@ func login(c *echo.Context) error {
 	username := c.FormValue("username")
 	password := c.FormValue("password")
 
-	// Throws unauthorized error
+	// Demo only: hard-coded credentials compared in plain text. In production,
+	// look up the user and verify a hashed password with a constant-time compare
+	// (e.g. golang.org/x/crypto/bcrypt's CompareHashAndPassword) to avoid timing attacks.
 	if username != "jon" || password != "shhh!" {
 		return echo.ErrUnauthorized
 	}

--- a/site/src/content/docs/ja/guide/binding.md
+++ b/site/src/content/docs/ja/guide/binding.md
@@ -46,6 +46,24 @@ if err := c.Bind(&user); err != nil {
 JSON と XML はタグが省略された場合、標準ライブラリと同じように struct フィールド名へ
 フォールバックします。
 
+### スライス
+
+繰り返し指定されたクエリ・パス・フォーム・ヘッダーの値はスライスフィールドにバインドされ、
+すべての出現が収集されます：
+
+```go
+// GET /search?tag=go&tag=web&tag=api
+type Filter struct {
+	Tags []string `query:"tag"`
+}
+
+var f Filter
+if err := c.Bind(&f); err != nil {
+	return c.String(http.StatusBadRequest, "bad request")
+}
+// f.Tags == []string{"go", "web", "api"}
+```
+
 ### ボディのコンテンツタイプ
 
 リクエストボディをデコードするときは、`Content-Type` header によってデコーダーが選ばれます。

--- a/site/src/content/docs/pt-br/cookbook/jwt.md
+++ b/site/src/content/docs/pt-br/cookbook/jwt.md
@@ -47,7 +47,9 @@ func login(c *echo.Context) error {
 	username := c.FormValue("username")
 	password := c.FormValue("password")
 
-	// Throws unauthorized error
+	// Demo only: hard-coded credentials compared in plain text. In production,
+	// look up the user and verify a hashed password with a constant-time compare
+	// (e.g. golang.org/x/crypto/bcrypt's CompareHashAndPassword) to avoid timing attacks.
 	if username != "jon" || password != "shhh!" {
 		return echo.ErrUnauthorized
 	}

--- a/site/src/content/docs/pt-br/guide/binding.md
+++ b/site/src/content/docs/pt-br/guide/binding.md
@@ -44,6 +44,24 @@ if err := c.Bind(&user); err != nil {
 Campos de path, query, header e form exigem uma **tag explícita**. JSON e XML usam
 o nome do campo da struct quando a tag é omitida, igual à biblioteca padrão.
 
+### Slices
+
+Valores repetidos de query, path, formulário ou header são vinculados a um campo
+slice, que coleta cada ocorrência:
+
+```go
+// GET /search?tag=go&tag=web&tag=api
+type Filter struct {
+	Tags []string `query:"tag"`
+}
+
+var f Filter
+if err := c.Bind(&f); err != nil {
+	return c.String(http.StatusBadRequest, "bad request")
+}
+// f.Tags == []string{"go", "web", "api"}
+```
+
 ### Tipos de conteúdo do body
 
 Ao decodificar o body do request, o header `Content-Type` seleciona o decoder:

--- a/site/src/content/docs/zh-cn/cookbook/jwt.md
+++ b/site/src/content/docs/zh-cn/cookbook/jwt.md
@@ -46,7 +46,9 @@ func login(c *echo.Context) error {
 	username := c.FormValue("username")
 	password := c.FormValue("password")
 
-	// Throws unauthorized error
+	// Demo only: hard-coded credentials compared in plain text. In production,
+	// look up the user and verify a hashed password with a constant-time compare
+	// (e.g. golang.org/x/crypto/bcrypt's CompareHashAndPassword) to avoid timing attacks.
 	if username != "jon" || password != "shhh!" {
 		return echo.ErrUnauthorized
 	}

--- a/site/src/content/docs/zh-cn/guide/binding.md
+++ b/site/src/content/docs/zh-cn/guide/binding.md
@@ -44,6 +44,23 @@ if err := c.Bind(&user); err != nil {
 路径、查询、header 和表单字段都需要**显式标签**。JSON 和 XML 在省略标签时会回退到
 struct 字段名，这与标准库的行为一致。
 
+### 切片
+
+重复的查询、路径、表单或请求头值会绑定到切片字段——该字段会收集每一个值：
+
+```go
+// GET /search?tag=go&tag=web&tag=api
+type Filter struct {
+	Tags []string `query:"tag"`
+}
+
+var f Filter
+if err := c.Bind(&f); err != nil {
+	return c.String(http.StatusBadRequest, "bad request")
+}
+// f.Tags == []string{"go", "web", "api"}
+```
+
 ### 请求体内容类型
 
 解码请求体时，`Content-Type` header 会选择对应的解码器：


### PR DESCRIPTION
Two small docs content fixes.

## #170 — Document binding repeated query params to a slice
Struct-tag binding to a slice field wasn't documented (only the fluent binder showed it). Adds a **Slices** subsection to the binding guide:

```go
// GET /search?tag=go&tag=web&tag=api
type Filter struct {
	Tags []string `query:"tag"`
}
// f.Tags == []string{"go", "web", "api"}
```

Across all 5 locales (heading + lead-in translated; code block identical).

## #100 — JWT example timing attack
The cookbook login handler compared hard-coded credentials with a plain `!=`. Replaced the bare `// Throws unauthorized error` comment with a caveat that it's demo-only and that production code should verify a **hashed password with a constant-time compare** (e.g. `bcrypt.CompareHashAndPassword`) to avoid timing attacks. Comment is identical across all 5 locales (matching the docs' code-comment convention).

## Verification
- Build passes (301 pages).

Closes #170
Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)