### PR TITLE
docs(cors): Security section on wildcard origin + credentials (#277)

### DIFF
--- a/site/src/content/docs/es/middleware/cors.md
+++ b/site/src/content/docs/es/middleware/cors.md
@@ -117,8 +117,23 @@ CORSConfig{
 }
 ```
 
-:::caution[Seguridad]
-Nunca combines `AllowCredentials = true` con un wildcard `AllowOrigins`. Cuando necesites
-validación dinámica de origin, usa `UnsafeAllowOriginFunc` y valida con cuidado:
-los atacantes pueden registrar nombres de (sub)dominio hostiles.
-:::
+## Seguridad
+
+Un origin con wildcard (`AllowOrigins: []string{"*"}`) combinado con `AllowCredentials: true`
+es peligroso: reflejaría el `Origin` de **cualquier** petición en
+`Access-Control-Allow-Origin`, permitiendo que una página de cualquier sitio haga peticiones
+cross-origin con credenciales a tu API (consulta [Exploiting CORS misconfigurations](https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html)).
+
+Echo rechaza esta combinación en lugar de construir un middleware inseguro: `CORS` y
+`CORSWithConfig` hacen **panic**, y `CORSConfig.ToMiddleware()` devuelve un error. Para permitir
+peticiones con credenciales, enumera explícitamente los orígenes de confianza:
+
+```go
+e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+	AllowOrigins:     []string{"https://example.com"},
+	AllowCredentials: true,
+}))
+```
+
+Para validación dinámica de origin, usa `UnsafeAllowOriginFunc` y valida cada origin con
+cuidado: los atacantes pueden registrar nombres de (sub)dominio falsos u hostiles.

--- a/site/src/content/docs/ja/middleware/cors.md
+++ b/site/src/content/docs/ja/middleware/cors.md
@@ -117,8 +117,23 @@ CORSConfig{
 }
 ```
 
-:::caution[セキュリティ]
-`AllowCredentials = true` とワイルドカードの `AllowOrigins` を組み合わせてはいけません。
-動的な origin 検証が必要な場合は `UnsafeAllowOriginFunc` を使い、慎重に検証してください。
-攻撃者が悪意ある（サブ）ドメイン名を登録する可能性があります。
-:::
+## セキュリティ
+
+ワイルドカード origin（`AllowOrigins: []string{"*"}`）と `AllowCredentials: true` の組み合わせは危険です。
+**任意**のリクエストの `Origin` をそのまま `Access-Control-Allow-Origin` に反射してしまい、
+どのサイトのページからでも認証情報付きのクロスオリジンリクエストを API に送れてしまいます
+（[Exploiting CORS misconfigurations](https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html) を参照）。
+
+Echo は安全でないミドルウェアを構築せず、この組み合わせを拒否します。`CORS` と `CORSWithConfig` は **panic** し、
+`CORSConfig.ToMiddleware()` はエラーを返します。認証情報付きのリクエストを許可するには、
+信頼する origin を明示的に列挙してください：
+
+```go
+e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+	AllowOrigins:     []string{"https://example.com"},
+	AllowCredentials: true,
+}))
+```
+
+動的な origin 検証が必要な場合は `UnsafeAllowOriginFunc` を使い、各 origin を慎重に検証してください。
+攻撃者が偽装または悪意ある（サブ）ドメイン名を登録する可能性があります。

--- a/site/src/content/docs/middleware/cors.md
+++ b/site/src/content/docs/middleware/cors.md
@@ -117,8 +117,23 @@ CORSConfig{
 }
 ```
 
-:::caution[Security]
-Never combine `AllowCredentials = true` with a wildcard `AllowOrigins`. When you need
-dynamic origin validation, use `UnsafeAllowOriginFunc` and validate carefully —
-attackers may register hostile (sub)domain names.
-:::
+## Security
+
+A wildcard origin (`AllowOrigins: []string{"*"}`) combined with `AllowCredentials: true`
+is dangerous: it would reflect **any** request's `Origin` back in
+`Access-Control-Allow-Origin`, letting a page on any site make credentialed cross-origin
+requests to your API (see [Exploiting CORS misconfigurations](https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html)).
+
+Echo refuses this combination rather than building an insecure middleware: `CORS` and
+`CORSWithConfig` **panic**, and `CORSConfig.ToMiddleware()` returns an error. To allow
+credentialed requests, list the trusted origins explicitly:
+
+```go
+e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+	AllowOrigins:     []string{"https://example.com"},
+	AllowCredentials: true,
+}))
+```
+
+For dynamic origin validation, use `UnsafeAllowOriginFunc` and validate each origin
+carefully — attackers may register look-alike or hostile (sub)domain names.

--- a/site/src/content/docs/pt-br/middleware/cors.md
+++ b/site/src/content/docs/pt-br/middleware/cors.md
@@ -117,8 +117,23 @@ CORSConfig{
 }
 ```
 
-:::caution[Segurança]
-Nunca combine `AllowCredentials = true` com um wildcard `AllowOrigins`. Quando precisar
-de validação dinâmica de origem, use `UnsafeAllowOriginFunc` e valide cuidadosamente —
-atacantes podem registrar nomes de (sub)domínio hostis.
-:::
+## Segurança
+
+Um origin curinga (`AllowOrigins: []string{"*"}`) combinado com `AllowCredentials: true`
+é perigoso: ele refletiria o `Origin` de **qualquer** requisição em
+`Access-Control-Allow-Origin`, permitindo que uma página de qualquer site faça requisições
+cross-origin com credenciais à sua API (veja [Exploiting CORS misconfigurations](https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html)).
+
+O Echo recusa essa combinação em vez de construir um middleware inseguro: `CORS` e
+`CORSWithConfig` causam **panic**, e `CORSConfig.ToMiddleware()` retorna um erro. Para permitir
+requisições com credenciais, liste explicitamente as origens confiáveis:
+
+```go
+e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+	AllowOrigins:     []string{"https://example.com"},
+	AllowCredentials: true,
+}))
+```
+
+Para validação dinâmica de origem, use `UnsafeAllowOriginFunc` e valide cada origem com
+cuidado — atacantes podem registrar nomes de (sub)domínio falsos ou hostis.

--- a/site/src/content/docs/zh-cn/middleware/cors.md
+++ b/site/src/content/docs/zh-cn/middleware/cors.md
@@ -117,7 +117,21 @@ CORSConfig{
 }
 ```
 
-:::caution[安全]
-永远不要把 `AllowCredentials = true` 与通配符 `AllowOrigins` 组合使用。需要动态 origin
-验证时，请使用 `UnsafeAllowOriginFunc` 并仔细验证，攻击者可能注册恶意（子）域名。
-:::
+## 安全
+
+通配符 origin（`AllowOrigins: []string{"*"}`）与 `AllowCredentials: true` 组合使用非常危险：
+它会把**任意**请求的 `Origin` 原样反射到 `Access-Control-Allow-Origin` 中，使得任意网站上的页面
+都能向你的 API 发起携带凭证的跨域请求（参见 [Exploiting CORS misconfigurations](https://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html)）。
+
+Echo 会拒绝这种组合，而不是构建不安全的中间件：`CORS` 和 `CORSWithConfig` 会 **panic**，
+`CORSConfig.ToMiddleware()` 会返回错误。要允许携带凭证的请求，请显式列出受信任的 origin：
+
+```go
+e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+	AllowOrigins:     []string{"https://example.com"},
+	AllowCredentials: true,
+}))
+```
+
+需要动态 origin 验证时，请使用 `UnsafeAllowOriginFunc` 并仔细验证每个 origin——
+攻击者可能注册仿冒或恶意的（子）域名。


### PR DESCRIPTION
Closes #277 (which tracked upstream [echo#2400](https://github.com/labstack/echo/issues/2400)).

## Background
echo#2400 reported that a wildcard origin + `AllowCredentials: true` reflects **any** request's `Origin` back in `Access-Control-Allow-Origin` — a cross-origin attack vector. The maintainer's resolution note: *"we need to add a security block to echo.labstack.com."* The CORS page only had a terse one-line caution.

## Change
Replaces that caution with a proper **Security** section that explains:
- **The danger** — wildcard `*` + `AllowCredentials: true` reflects any `Origin`, allowing credentialed cross-origin requests from any site (links to the PortSwigger write-up).
- **v5's enforcement** — `CORS` and `CORSWithConfig` **panic**, and `CORSConfig.ToMiddleware()` returns an error, instead of building the insecure middleware (verified against echo v5 `middleware/cors.go`).
- **The safe pattern** — enumerate trusted origins explicitly; use `UnsafeAllowOriginFunc` for dynamic validation, with a caution about hostile subdomains.

Applied across all 5 locales (translated prose, identical code block).

## Verification
- Build passes (301 pages).
- Behavior statements checked against echo v5 source: `toMiddlewareOrPanic` and the `"* as allowed origin and AllowCredentials=true is insecure and not allowed"` error.

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)