### PR TITLE
docs(routing): clarify Any registers handler for any HTTP method

### DIFF
--- a/site/src/content/docs/es/guide/routing.md
+++ b/site/src/content/docs/es/guide/routing.md
@@ -23,12 +23,17 @@ e.DELETE("/users/:id", deleteUser)
 e.GET("/static/*", serveFiles)    // wildcard
 ```
 
-`Any` registra un handler para todos los métodos soportados, y `Match` para un conjunto específico:
+`Any` registra un handler para cualquier método HTTP — incluidos los que no están en
+la lista predefinida de Echo — y `Match` para un conjunto específico:
 
 ```go
 e.Any("/ping", pong)
 e.Match([]string{http.MethodGet, http.MethodPost}, "/form", handleForm)
 ```
+
+:::note
+Una ruta de método específico registrada para el mismo path tiene precedencia sobre la ruta `Any`.
+:::
 
 ## Tipos de coincidencia
 

--- a/site/src/content/docs/guide/routing.md
+++ b/site/src/content/docs/guide/routing.md
@@ -23,12 +23,17 @@ e.DELETE("/users/:id", deleteUser)
 e.GET("/static/*", serveFiles)    // wildcard
 ```
 
-`Any` registers a handler for all supported methods, and `Match` for a specific set:
+`Any` registers a handler for any HTTP method — including ones not in Echo's predefined
+list — and `Match` for a specific set:
 
 ```go
 e.Any("/ping", pong)
 e.Match([]string{http.MethodGet, http.MethodPost}, "/form", handleForm)
 ```
+
+:::note
+A method-specific route registered for the same path takes precedence over the `Any` route.
+:::
 
 ## Match types
 

--- a/site/src/content/docs/ja/guide/routing.md
+++ b/site/src/content/docs/ja/guide/routing.md
@@ -24,12 +24,17 @@ e.DELETE("/users/:id", deleteUser)
 e.GET("/static/*", serveFiles)    // wildcard
 ```
 
-`Any` はサポートされているすべてのメソッドにハンドラを登録し、`Match` は指定した集合に登録します。
+`Any` は任意の HTTP メソッド（Echo にあらかじめ定義された一覧にないものも含む）にハンドラを
+登録し、`Match` は指定した集合に登録します。
 
 ```go
 e.Any("/ping", pong)
 e.Match([]string{http.MethodGet, http.MethodPost}, "/form", handleForm)
 ```
+
+:::note
+同じパスに登録されたメソッド固有のルートは、`Any` ルートより優先されます。
+:::
 
 ## マッチ種別
 

--- a/site/src/content/docs/pt-br/guide/routing.md
+++ b/site/src/content/docs/pt-br/guide/routing.md
@@ -23,12 +23,17 @@ e.DELETE("/users/:id", deleteUser)
 e.GET("/static/*", serveFiles)    // wildcard
 ```
 
-`Any` registra um handler para todos os métodos suportados, e `Match` para um conjunto específico:
+`Any` registra um handler para qualquer método HTTP — incluindo os que não estão na
+lista predefinida do Echo — e `Match` para um conjunto específico:
 
 ```go
 e.Any("/ping", pong)
 e.Match([]string{http.MethodGet, http.MethodPost}, "/form", handleForm)
 ```
+
+:::note
+Uma rota de método específico registrada para o mesmo caminho tem precedência sobre a rota `Any`.
+:::
 
 ## Tipos de correspondência
 

--- a/site/src/content/docs/zh-cn/guide/routing.md
+++ b/site/src/content/docs/zh-cn/guide/routing.md
@@ -23,12 +23,16 @@ e.DELETE("/users/:id", deleteUser)
 e.GET("/static/*", serveFiles)    // wildcard
 ```
 
-`Any` 会为所有支持的方法注册处理函数，`Match` 则用于一组指定方法：
+`Any` 会为任意 HTTP 方法（包括不在 Echo 预定义列表中的方法）注册处理函数，`Match` 则用于一组指定方法：
 
 ```go
 e.Any("/ping", pong)
 e.Match([]string{http.MethodGet, http.MethodPost}, "/form", handleForm)
 ```
+
+:::note
+为同一路径注册的特定方法路由优先于 `Any` 路由。
+:::
 
 ## 匹配类型
 


### PR DESCRIPTION
## Summary

Related to labstack/echo#3044.

Clarifies the routing documentation around `e.Any()`. The previous wording ("registers a handler for all supported methods") was inaccurate — `Any` registers a handler for *any* HTTP method, including methods not in Echo's predefined list.

## Changes

- Reword the `Any` description to say it registers a handler for any HTTP method, including ones not in Echo's predefined list.
- Add a note clarifying that a method-specific route registered for the same path takes precedence over the `Any` route.
- Apply the same updates across all translations (en, es, ja, pt-br, zh-cn).

## Notes

Documentation only — no code changes.