### PR TITLE
Fix undefined echo.Map in homepage Hello World example

### DIFF
--- a/site/src/components/HomeHero.astro
+++ b/site/src/components/HomeHero.astro
@@ -35,7 +35,7 @@ import { starsLabel, echoVersion } from '../data/github.ts';
 <span class="kw">func</span> <span class="fnn">main</span>() &#123;
     e := echo.<span class="fnn">New</span>()
     e.<span class="fnn">GET</span>(<span class="str">"/"</span>, <span class="kw">func</span>(c *echo.Context) <span class="kw">error</span> &#123;
-        <span class="kw">return</span> c.<span class="fnn">JSON</span>(<span class="str">200</span>, echo.Map&#123;<span class="str">"message"</span>: <span class="str">"Hello, World!"</span>&#125;)
+        <span class="kw">return</span> c.<span class="fnn">JSON</span>(<span class="str">200</span>, <span class="kw">map</span>[<span class="kw">string</span>]<span class="kw">string</span>&#123;<span class="str">"message"</span>: <span class="str">"Hello, World!"</span>&#125;)
     &#125;)
     e.<span class="fnn">Start</span>(<span class="str">":1323"</span>)
 &#125;</pre>


### PR DESCRIPTION
## Summary

The homepage Hello World example (`site/src/components/HomeHero.astro`) used `echo.Map{"message": "Hello, World!"}`, but `echo.Map` does not exist as a type in Echo v5. Copying the homepage example as-is fails to compile.

This replaces it with a plain `map[string]string{"message": "Hello, World!"}`, matching the pattern already used in the v5 Quickstart docs.

## Why this PR targets echox instead of echo

The issue was filed on `labstack/echo` (labstack/echo#3065) because that's the natural place to report a docs/website bug, but the homepage/website source actually lives in this repo (`labstack/echox`). This PR fixes the bug where the code actually lives.

Fixes labstack/echo#3065

## Test plan

- [x] `npm ci && npx astro build` in `site/` completes successfully with no errors
- [x] Confirmed `echo.Map` no longer appears anywhere in the built output
- [x] Confirmed the Echo v5 `Context.JSON(code int, i any)` signature accepts `map[string]string`, so the example now compiles as advertised